### PR TITLE
[codex] Preserve repeated field names during decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ const value = decode<{
 }>(entries);
 ```
 
+When the same decoded field path appears more than once, `decode()` preserves every value by collecting them into an array in entry order.
+
+```ts
+decode([
+  ["tags", "a"],
+  ["tags", "b"],
+]);
+// => { tags: ["a", "b"] }
+```
+
 ## Decode a Request
 
 ```ts

--- a/src/path.ts
+++ b/src/path.ts
@@ -18,6 +18,26 @@ export function appendIndex(path: string, index: number): string {
 export type PathSegment = string | number;
 type PathContainer = Record<string | number, unknown>;
 
+function assignPathValue(
+  container: PathContainer,
+  segment: PathSegment,
+  value: unknown,
+): void {
+  const existing = container[segment];
+
+  if (existing === undefined) {
+    container[segment] = value;
+    return;
+  }
+
+  if (Array.isArray(existing)) {
+    existing.push(value);
+    return;
+  }
+
+  container[segment] = [existing, value];
+}
+
 export function parsePath(path: string): PathSegment[] {
   if (path === "") return [];
 
@@ -88,7 +108,7 @@ export function unflatten(entries: [string, unknown][]): unknown {
     }
 
     const lastSeg = segments[segments.length - 1]!;
-    current[lastSeg] = value;
+    assignPathValue(current, lastSeg, value);
   }
 
   return root;

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -153,4 +153,23 @@ describe("unflatten", () => {
       ]),
     ).toEqual({ items: [{ name: "x" }, { name: "y" }] });
   });
+
+  test("repeated flat keys become arrays", () => {
+    expect(
+      unflatten([
+        ["tags", "a"],
+        ["tags", "b"],
+        ["tags", "c"],
+      ]),
+    ).toEqual({ tags: ["a", "b", "c"] });
+  });
+
+  test("repeated nested keys become arrays", () => {
+    expect(
+      unflatten([
+        ["user.tags", "a"],
+        ["user.tags", "b"],
+      ]),
+    ).toEqual({ user: { tags: ["a", "b"] } });
+  });
 });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -364,6 +364,34 @@ describe("encode/decode round-trip", () => {
     expect(decode<typeof original>(formData)).toEqual(original);
   });
 
+  test("decode preserves repeated field names as arrays", () => {
+    expect(
+      decode<{
+        tags: string[];
+      }>([
+        ["tags", "a"],
+        ["tags", "b"],
+      ]),
+    ).toEqual({ tags: ["a", "b"] });
+  });
+
+  test("decode preserves repeated typed field names as arrays", () => {
+    expect(
+      decode<{
+        createdAt: Date[];
+      }>([
+        ["createdAt", "2024-01-01T00:00:00.000Z"],
+        ["createdAt", "2024-06-01T00:00:00.000Z"],
+        ["$types", JSON.stringify({ createdAt: "Date" })],
+      ]),
+    ).toEqual({
+      createdAt: [
+        new Date("2024-01-01T00:00:00.000Z"),
+        new Date("2024-06-01T00:00:00.000Z"),
+      ],
+    });
+  });
+
   test("custom typesKey", () => {
     const input = { count: 42, $types: "user data here" };
     const entries = encode(input, { typesKey: "__meta" });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -364,6 +364,18 @@ describe("encode/decode round-trip", () => {
     expect(decode<typeof original>(formData)).toEqual(original);
   });
 
+  test("decode preserves repeated field names from FormData", () => {
+    const formData = new FormData();
+    formData.append("tags", "a");
+    formData.append("tags", "b");
+
+    expect(
+      decode<{
+        tags: string[];
+      }>(formData),
+    ).toEqual({ tags: ["a", "b"] });
+  });
+
   test("decode preserves repeated field names as arrays", () => {
     expect(
       decode<{


### PR DESCRIPTION
## Summary
Preserve all values when `decode()` sees the same field path more than once instead of overwriting earlier entries.

## Why
Issue #1 reports that repeated form field names such as checkbox groups and multi-value inputs collapse to the last value during decode. The overwrite happened inside `unflatten()`, which assigned each parsed path directly into the target object.

## What changed
- merge duplicate decoded paths into arrays in insertion order
- add tests for repeated flat and nested keys
- add decode coverage for repeated typed values
- document the repeated-key mapping in the README

## Impact
Repeated field names now round-trip losslessly through `decode()`. Existing indexed array paths such as `items[0]` are unchanged.

## Validation
- `bun test`
- `bun run typecheck`

Closes #1
