### PR TITLE
fix: exclude buttons from encode(form) unless passed as submitter

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -6,6 +6,16 @@ export const DEFAULT_TYPES_KEY = "$types";
 export interface EncodeOptions {
   typesKey?: string;
   types?: Record<string, string>;
+  /**
+   * The element used to submit the form, mirroring `new FormData(form, submitter)`.
+   * Only submit buttons (`<button>`, `input[type=submit]`) that equal this element
+   * are included in the encoded output.
+   *
+   * Note: `input[type=image]` is recognised as a submit button and included when it
+   * equals the submitter, but the encoded value is `[name, value]` rather than the
+   * `[name.x, clickX]` / `[name.y, clickY]` pairs a real browser submission produces,
+   * because the originating click coordinates are not available here.
+   */
   submitter?: HTMLElement | null;
 }
 
@@ -69,7 +79,7 @@ function encodeForm(
     }
 
     // input[type=submit] and input[type=image] follow the same rule
-    if (el instanceof HTMLInputElement && (el.type === "submit" || el.type === "image")) {
+    if (el instanceof HTMLInputElement && isSubmitButton(el)) {
       if (el === submitter) {
         entries.push([el.name, el.value]);
       }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -38,7 +38,7 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
 
 function isSubmitButton(el: Element): boolean {
   if (el instanceof HTMLButtonElement) {
-    return el.type === "submit" || el.type === "";
+    return el.type === "submit";
   }
   if (el instanceof HTMLInputElement) {
     return el.type === "submit" || el.type === "image";

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -6,6 +6,7 @@ export const DEFAULT_TYPES_KEY = "$types";
 export interface EncodeOptions {
   typesKey?: string;
   types?: Record<string, string>;
+  submitter?: HTMLElement | null;
 }
 
 export function encode<T>(input: T, options?: EncodeOptions): [string, string][] {
@@ -13,7 +14,7 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
 
   // HTMLFormElement
   if (typeof HTMLFormElement !== "undefined" && input instanceof HTMLFormElement) {
-    return encodeForm(input, typesKey, options?.types);
+    return encodeForm(input, typesKey, options?.types, options?.submitter);
   }
 
   // FormData
@@ -35,10 +36,21 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
   return entries;
 }
 
+function isSubmitButton(el: Element): boolean {
+  if (el instanceof HTMLButtonElement) {
+    return el.type === "submit" || el.type === "";
+  }
+  if (el instanceof HTMLInputElement) {
+    return el.type === "submit" || el.type === "image";
+  }
+  return false;
+}
+
 function encodeForm(
   form: HTMLFormElement,
   typesKey: string,
   explicitTypes?: Record<string, string>,
+  submitter?: HTMLElement | null,
 ): [string, string][] {
   const entries: [string, string][] = [];
   const types: Record<string, string> = { ...explicitTypes };
@@ -47,6 +59,22 @@ function encodeForm(
     const el = element as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
     if (!el.name || el.disabled) continue;
     if (el.name === typesKey) continue;
+
+    // Buttons are only successful controls when they are the submitter
+    if (el instanceof HTMLButtonElement) {
+      if (isSubmitButton(el) && el === submitter) {
+        entries.push([el.name, el.value]);
+      }
+      continue;
+    }
+
+    // input[type=submit] and input[type=image] follow the same rule
+    if (el instanceof HTMLInputElement && (el.type === "submit" || el.type === "image")) {
+      if (el === submitter) {
+        entries.push([el.name, el.value]);
+      }
+      continue;
+    }
 
     const typeId = (el as HTMLInputElement).dataset?.sfType ?? types[el.name];
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -215,6 +215,56 @@ describe("encode(form)", () => {
     expect(entries.find(([k]) => k === "$types")).toBeUndefined();
   });
 
+  test("excludes button elements by default (no submitter)", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><button name="action" value="save">Save</button>',
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([["title", "hello"]]);
+  });
+
+  test("includes button when passed as submitter", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><button name="action" value="save">Save</button>',
+    );
+    const button = form.querySelector<HTMLButtonElement>("button")!;
+    const entries = encode(form, { submitter: button });
+
+    expect(entries).toContainEqual(["title", "hello"]);
+    expect(entries).toContainEqual(["action", "save"]);
+  });
+
+  test("always excludes button[type=button]", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><button name="action" type="button" value="click">Click</button>',
+    );
+    const button = form.querySelector<HTMLButtonElement>("button")!;
+    const entries = encode(form, { submitter: button });
+
+    expect(entries).toEqual([["title", "hello"]]);
+  });
+
+  test("excludes input[type=submit] without submitter", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><input name="sub" type="submit" value="Send" />',
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([["title", "hello"]]);
+  });
+
+  test("includes input[type=submit] when passed as submitter", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><input name="sub" type="submit" value="Send" />',
+    );
+    const submitInput = form.querySelector<HTMLInputElement>('input[type="submit"]')!;
+    const entries = encode(form, { submitter: submitInput });
+
+    expect(entries).toContainEqual(["title", "hello"]);
+    expect(entries).toContainEqual(["sub", "Send"]);
+  });
+
   test("encode(form) round-trips through decode", () => {
     const form = createForm(
       '<input name="name" value="Alice" />' +

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -265,6 +265,26 @@ describe("encode(form)", () => {
     expect(entries).toContainEqual(["sub", "Send"]);
   });
 
+  test("includes input[type=image] when passed as submitter (encodes name+value, not coordinates)", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><input name="img" type="image" value="go" />',
+    );
+    const imageInput = form.querySelector<HTMLInputElement>('input[type="image"]')!;
+    const entries = encode(form, { submitter: imageInput });
+
+    expect(entries).toContainEqual(["title", "hello"]);
+    expect(entries).toContainEqual(["img", "go"]);
+  });
+
+  test("excludes input[type=image] without submitter", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><input name="img" type="image" value="go" />',
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([["title", "hello"]]);
+  });
+
   test("encode(form) round-trips through decode", () => {
     const form = createForm(
       '<input name="name" value="Alice" />' +


### PR DESCRIPTION
## Summary

- Adds `submitter?: HTMLElement | null` to `EncodeOptions` to mirror the `FormData(form, submitter)` browser API
- `HTMLButtonElement` instances are now skipped unless they equal the `submitter` option and their `type` is `"submit"` (the default); `type="button"` and `type="reset"` are always excluded
- `input[type=submit]` and `input[type=image]` follow the same rule
- Fixes the payload divergence from real browser form submission described in #3

## Test plan

- [x] `<button>` without submitter is excluded
- [x] `<button>` passed as `submitter` is included
- [x] `<button type="button">` is always excluded even when passed as `submitter`
- [x] `input[type=submit]` without submitter is excluded
- [x] `input[type=submit]` passed as `submitter` is included
- [x] Full test suite passes (153 tests)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)