### PR TITLE
fix: throw TypeError when File entries are encountered

### DIFF
--- a/.changeset/fix-file-entry-loud-error.md
+++ b/.changeset/fix-file-entry-loud-error.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+`encode()` and `decode()` now throw a descriptive `TypeError` when they encounter a `File` entry (from a file input or `FormData`) instead of silently dropping it. This prevents multipart forms from appearing to work while quietly discarding attachments.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -17,8 +17,11 @@ export function decode<T = unknown>(
   let typesJson: string | undefined;
 
   for (const [key, value] of data) {
-    // Skip File entries
-    if (typeof value !== "string") continue;
+    if (typeof value !== "string") {
+      throw new TypeError(
+        `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately.`,
+      );
+    }
     if (key === typesKey) {
       typesJson = value;
     } else {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -115,8 +115,11 @@ function encodeForm(
       continue;
     }
 
-    // Skip file inputs
-    if (input.type === "file") continue;
+    if (input.type === "file") {
+      throw new TypeError(
+        `File inputs are not supported by superformdata (field: "${input.name}"). Handle file uploads separately.`,
+      );
+    }
 
     entries.push([el.name, input.value]);
     if (typeId) types[el.name] = typeId;
@@ -138,7 +141,11 @@ function encodeFormData(
   let existingTypes: Record<string, string> | undefined;
 
   for (const [key, value] of data) {
-    if (typeof value !== "string") continue;
+    if (typeof value !== "string") {
+      throw new TypeError(
+        `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately.`,
+      );
+    }
     if (key === typesKey) {
       try {
         existingTypes = JSON.parse(value);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -200,11 +200,10 @@ describe("encode(form)", () => {
     expect(entries).toEqual([["color", "blue"]]);
   });
 
-  test("skips file inputs", () => {
+  test("throws on file inputs", () => {
     const form = createForm('<input name="name" value="Alice" /><input name="file" type="file" />');
-    const entries = encode(form);
 
-    expect(entries).toEqual([["name", "Alice"]]);
+    expect(() => encode(form)).toThrow(/File inputs are not supported/);
   });
 
   test("encodes with custom typesKey", () => {
@@ -367,13 +366,11 @@ describe("encode(FormData)", () => {
     expect(result.count).toBe(42);
   });
 
-  test("skips File entries", () => {
+  test("throws on File entries", () => {
     const fd = new FormData();
     fd.append("name", "Alice");
     fd.append("file", new File(["content"], "test.txt"));
 
-    const entries = encode(fd);
-
-    expect(entries).toEqual([["name", "Alice"]]);
+    expect(() => encode(fd)).toThrow(/File entries are not supported/);
   });
 });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -339,17 +339,14 @@ describe("encode/decode round-trip", () => {
     ).toThrow("malformed JSON");
   });
 
-  test("decode ignores File entries in FormData", () => {
+  test("decode throws on File entries in FormData", () => {
     const formData = new FormData();
     formData.append("name", "Alice");
     formData.append("file", new File(["content"], "test.txt"));
     formData.append("age", "30");
     formData.append("$types", JSON.stringify({ age: "number" }));
 
-    const result = decode(formData) as Record<string, unknown>;
-    expect(result.name).toBe("Alice");
-    expect(result.age).toBe(30);
-    expect(result).not.toHaveProperty("file");
+    expect(() => decode(formData)).toThrow(/File entries are not supported/);
   });
 
   test("decode from FormData", () => {


### PR DESCRIPTION
## Summary

Closes #4.

- `encode(form)` now throws a `TypeError` when it encounters an `<input type="file">` instead of silently skipping it.
- `encode(FormData)` now throws a `TypeError` when a `FormData` entry is a `File` object instead of silently skipping it.
- `decode()` now throws a `TypeError` when a `FormData` entry is a `File` object instead of silently skipping it.

All three error messages include the field name and a note to handle file uploads separately, making it immediately clear what went wrong.

The three existing tests that asserted the old silent-drop behaviour have been updated to assert the new `TypeError`, and the changeset is included.

## Test plan

- [x] Updated `test/client.test.ts`: "throws on file inputs" and "throws on File entries" assert `TypeError` with `/File inputs are not supported/` and `/File entries are not supported/`
- [x] Updated `test/roundtrip.test.ts`: "decode throws on File entries in FormData" asserts `TypeError` with `/File entries are not supported/`
- [x] All 155 tests pass (`bun test`)
- [x] No type errors (`bun typecheck`)
- [x] No lint warnings (`bun lint:fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)