### PR TITLE
[codex] Fix custom typesKey support in browser change helpers

### DIFF
--- a/.changeset/five-custom-types-key.md
+++ b/.changeset/five-custom-types-key.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+The browser change helpers now support custom `typesKey` metadata fields consistently via `createChangeHandlers({ typesKey })`, and the built-in boolean helper no longer hard-codes `$types` internally.

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,11 +25,11 @@ function updateFormTypes(
   const input =
     existingInput ??
     (() => {
-      const input = document.createElement("input");
-      input.type = "hidden";
-      input.name = typesKey;
-      form.appendChild(input);
-      return input;
+      const newInput = document.createElement("input");
+      newInput.type = "hidden";
+      newInput.name = typesKey;
+      form.appendChild(newInput);
+      return newInput;
     })();
 
   const types: Record<string, string> = input.value ? JSON.parse(input.value) : {};

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,28 +1,54 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
 
+export interface ChangeHandlerOptions {
+  readonly typesKey?: string;
+}
+
+export interface ChangeHandlers {
+  readonly onDateChange: (event: Event) => void;
+  readonly onNumberChange: (event: Event) => void;
+  readonly onBooleanChange: (event: Event) => void;
+  readonly onBigIntChange: (event: Event) => void;
+  readonly onURLChange: (event: Event) => void;
+}
+
 function updateFormTypes(
   form: HTMLFormElement,
   name: string,
   typeId: string,
   typesKey: string,
 ): void {
-  let input = form.querySelector<HTMLInputElement>(
+  const existingInput = form.querySelector<HTMLInputElement>(
     `input[type="hidden"][name="${CSS.escape(typesKey)}"]`,
   );
 
-  if (!input) {
-    input = document.createElement("input");
-    input.type = "hidden";
-    input.name = typesKey;
-    form.appendChild(input);
-  }
+  const input =
+    existingInput ??
+    (() => {
+      const input = document.createElement("input");
+      input.type = "hidden";
+      input.name = typesKey;
+      form.appendChild(input);
+      return input;
+    })();
 
   const types: Record<string, string> = input.value ? JSON.parse(input.value) : {};
   types[name] = typeId;
   input.value = JSON.stringify(types);
 }
 
-export function onChange(typeId: string, options?: { typesKey?: string }): (event: Event) => void {
+function createBooleanChangeHandler(typesKey: string): (event: Event) => void {
+  return (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    if (!input.name || !input.form) return;
+
+    input.dataset.sfType = "boolean";
+    input.value = String(input.checked);
+    updateFormTypes(input.form, input.name, "boolean", typesKey);
+  };
+}
+
+export function onChange(typeId: string, options?: ChangeHandlerOptions): (event: Event) => void {
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
 
   return (event: Event) => {
@@ -34,16 +60,22 @@ export function onChange(typeId: string, options?: { typesKey?: string }): (even
   };
 }
 
-export const onDateChange: (event: Event) => void = onChange("Date");
-export const onNumberChange: (event: Event) => void = onChange("number");
-export const onBigIntChange: (event: Event) => void = onChange("bigint");
-export const onURLChange: (event: Event) => void = onChange("URL");
+export function createChangeHandlers(options?: ChangeHandlerOptions): ChangeHandlers {
+  const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
 
-export const onBooleanChange: (event: Event) => void = (event: Event) => {
-  const input = event.target as HTMLInputElement;
-  if (!input.name || !input.form) return;
+  return {
+    onDateChange: onChange("Date", { typesKey }),
+    onNumberChange: onChange("number", { typesKey }),
+    onBooleanChange: createBooleanChangeHandler(typesKey),
+    onBigIntChange: onChange("bigint", { typesKey }),
+    onURLChange: onChange("URL", { typesKey }),
+  };
+}
 
-  input.dataset.sfType = "boolean";
-  input.value = String(input.checked);
-  updateFormTypes(input.form, input.name, "boolean", DEFAULT_TYPES_KEY);
-};
+const defaultHandlers = createChangeHandlers();
+
+export const onDateChange: (event: Event) => void = defaultHandlers.onDateChange;
+export const onNumberChange: (event: Event) => void = defaultHandlers.onNumberChange;
+export const onBooleanChange: (event: Event) => void = defaultHandlers.onBooleanChange;
+export const onBigIntChange: (event: Event) => void = defaultHandlers.onBigIntChange;
+export const onURLChange: (event: Event) => void = defaultHandlers.onURLChange;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { encode } from "./encode.ts";
 export { decode, decodeRequest } from "./decode.ts";
 export {
+  createChangeHandlers,
   onChange,
   onDateChange,
   onNumberChange,
@@ -8,5 +9,6 @@ export {
   onBigIntChange,
   onURLChange,
 } from "./client.ts";
+export type { ChangeHandlerOptions, ChangeHandlers } from "./client.ts";
 export type { EncodeOptions } from "./encode.ts";
 export type { DecodeOptions } from "./decode.ts";

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -67,17 +67,20 @@ describe("onChange handlers", () => {
 
   test("createChangeHandlers respects custom typesKey", () => {
     const form = createForm(
-      '<input name="count" type="number" /><input name="active" type="checkbox" />',
+      '<input name="count" type="number" /><input name="active" type="checkbox" /><input name="createdAt" type="date" />',
     );
     const countInput = form.querySelector<HTMLInputElement>('input[name="count"]')!;
     const activeInput = form.querySelector<HTMLInputElement>('input[name="active"]')!;
+    const createdAtInput = form.querySelector<HTMLInputElement>('input[name="createdAt"]')!;
     const handlers = createChangeHandlers({ typesKey: "__meta" });
 
     countInput.value = "42";
     activeInput.checked = true;
+    createdAtInput.value = "2024-01-01";
 
     handlers.onNumberChange({ target: countInput } as unknown as Event);
     handlers.onBooleanChange({ target: activeInput } as unknown as Event);
+    handlers.onDateChange({ target: createdAtInput } as unknown as Event);
 
     expect(form.querySelector<HTMLInputElement>('input[name="$types"]')).toBeNull();
     const typesInput = form.querySelector<HTMLInputElement>('input[name="__meta"]');
@@ -85,6 +88,7 @@ describe("onChange handlers", () => {
     expect(JSON.parse(typesInput!.value)).toEqual({
       active: "boolean",
       count: "number",
+      createdAt: "Date",
     });
   });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -3,6 +3,7 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { decode } from "../src/decode.ts";
 import { encode } from "../src/encode.ts";
 import {
+  createChangeHandlers,
   onBigIntChange,
   onBooleanChange,
   onChange,
@@ -62,6 +63,29 @@ describe("onChange handlers", () => {
 
     const types = JSON.parse(form.querySelector<HTMLInputElement>('input[name="$types"]')!.value);
     expect(types.count).toBe("number");
+  });
+
+  test("createChangeHandlers respects custom typesKey", () => {
+    const form = createForm(
+      '<input name="count" type="number" /><input name="active" type="checkbox" />',
+    );
+    const countInput = form.querySelector<HTMLInputElement>('input[name="count"]')!;
+    const activeInput = form.querySelector<HTMLInputElement>('input[name="active"]')!;
+    const handlers = createChangeHandlers({ typesKey: "__meta" });
+
+    countInput.value = "42";
+    activeInput.checked = true;
+
+    handlers.onNumberChange({ target: countInput } as unknown as Event);
+    handlers.onBooleanChange({ target: activeInput } as unknown as Event);
+
+    expect(form.querySelector<HTMLInputElement>('input[name="$types"]')).toBeNull();
+    const typesInput = form.querySelector<HTMLInputElement>('input[name="__meta"]');
+    expect(typesInput).toBeDefined();
+    expect(JSON.parse(typesInput!.value)).toEqual({
+      active: "boolean",
+      count: "number",
+    });
   });
 
   test("onBooleanChange sets value from checked state", () => {


### PR DESCRIPTION
## Summary

Fix Issue #5 by making the browser change helpers respect custom `typesKey` metadata fields consistently.

## What changed

- added `createChangeHandlers({ typesKey })` so consumers can create the built-in date, number, boolean, bigint, and URL handlers against a custom metadata field
- kept the existing `onDateChange`, `onNumberChange`, `onBooleanChange`, `onBigIntChange`, and `onURLChange` exports as the default `$types`-backed handlers
- removed the boolean helper’s internal hard-code of `$types`
- added a regression test covering custom metadata keys with both number and boolean helpers
- added a patch changeset for release notes

## Root cause

The prebuilt client helpers were bound to the default `$types` key at module definition time, and the boolean helper also hard-coded that key internally. That meant `encode(form, { typesKey: "__meta" })` could disagree with the helpers and emit mismatched metadata entries.

## Impact

Consumers using a custom metadata field can now use the browser helpers without generating duplicate or ambiguous type metadata.

## Validation

- `bun fmt`
- `bun run lint:fix`
- `bun run lint`
- `bun test`
- `bun run typecheck`
- `bun run build`

Closes #5
