### PR TITLE
[codex] Harden malformed form type metadata

### DIFF
--- a/.changeset/harden-malformed-types-metadata.md
+++ b/.changeset/harden-malformed-types-metadata.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+The browser change helpers now reset malformed hidden metadata instead of throwing when updating field type information.

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,17 @@ export interface ChangeHandlers {
   readonly onURLChange: (event: Event) => void;
 }
 
+function parseFormTypes(value: string): Record<string, string> {
+  if (!value) return {};
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 function updateFormTypes(
   form: HTMLFormElement,
   name: string,
@@ -32,7 +43,7 @@ function updateFormTypes(
       return newInput;
     })();
 
-  const types: Record<string, string> = input.value ? JSON.parse(input.value) : {};
+  const types = parseFormTypes(input.value);
   types[name] = typeId;
   input.value = JSON.stringify(types);
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -77,6 +77,30 @@ describe("onChange handlers", () => {
     expect(types).toEqual({ count: "number" });
   });
 
+  test("onNumberChange resets array hidden metadata", () => {
+    const form = createForm(
+      '<input name="count" type="number" /><input type="hidden" name="$types" value="[1,2,3]" />',
+    );
+    const input = form.querySelector<HTMLInputElement>('input[name="count"]')!;
+
+    expect(() => onNumberChange({ target: input } as unknown as Event)).not.toThrow();
+
+    const types = JSON.parse(form.querySelector<HTMLInputElement>('input[name="$types"]')!.value);
+    expect(types).toEqual({ count: "number" });
+  });
+
+  test("onNumberChange resets primitive hidden metadata", () => {
+    const form = createForm(
+      '<input name="count" type="number" /><input type="hidden" name="$types" value="42" />',
+    );
+    const input = form.querySelector<HTMLInputElement>('input[name="count"]')!;
+
+    expect(() => onNumberChange({ target: input } as unknown as Event)).not.toThrow();
+
+    const types = JSON.parse(form.querySelector<HTMLInputElement>('input[name="$types"]')!.value);
+    expect(types).toEqual({ count: "number" });
+  });
+
   test("createChangeHandlers respects custom typesKey", () => {
     const form = createForm(
       '<input name="count" type="number" /><input name="active" type="checkbox" /><input name="createdAt" type="date" />',

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -65,6 +65,18 @@ describe("onChange handlers", () => {
     expect(types.count).toBe("number");
   });
 
+  test("onNumberChange resets malformed hidden metadata", () => {
+    const form = createForm(
+      '<input name="count" type="number" /><input type="hidden" name="$types" value="not-json" />',
+    );
+    const input = form.querySelector<HTMLInputElement>('input[name="count"]')!;
+
+    expect(() => onNumberChange({ target: input } as unknown as Event)).not.toThrow();
+
+    const types = JSON.parse(form.querySelector<HTMLInputElement>('input[name="$types"]')!.value);
+    expect(types).toEqual({ count: "number" });
+  });
+
   test("createChangeHandlers respects custom typesKey", () => {
     const form = createForm(
       '<input name="count" type="number" /><input name="active" type="checkbox" /><input name="createdAt" type="date" />',


### PR DESCRIPTION
## Summary

Fixes #6.

The browser change helpers now parse the hidden type metadata defensively. If the existing metadata input contains malformed JSON, an array, or another non-object JSON value, the helpers reset the metadata to an empty object before recording the changed field type.

## Root Cause

`updateFormTypes()` called `JSON.parse(input.value)` directly whenever the hidden metadata input had a value. A stale DOM value or user-edited hidden field such as `value="not-json"` could therefore throw a `SyntaxError` during `onNumberChange()` and break the form interaction flow.

## Impact

Malformed hidden metadata no longer crashes client-side change handlers. Existing valid metadata continues to be preserved and updated, while invalid metadata is replaced with the current field's type information.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run fmt:check`
- `bun lint`
- `bun run test`
- `bun typecheck`
- `bun run build`

## Changeset

Added a patch changeset for `superformdata`.
