### PR TITLE
fix: reject pathological array indexes during decode

### DIFF
--- a/.changeset/reject-pathological-array-indexes.md
+++ b/.changeset/reject-pathological-array-indexes.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject invalid or oversized bracket indexes during decode to avoid constructing pathological sparse arrays from untrusted input.

--- a/src/path.ts
+++ b/src/path.ts
@@ -15,6 +15,9 @@ export function appendIndex(path: string, index: number): string {
   return `${path}[${index}]`;
 }
 
+const MAX_ARRAY_INDEX = 100_000;
+const ARRAY_INDEX_PATTERN = /^(?:0|[1-9]\d*)$/;
+
 export type PathSegment = string | number;
 type PathContainer = Record<string | number, unknown>;
 
@@ -32,6 +35,22 @@ function assignPathValue(container: PathContainer, segment: PathSegment, value: 
   }
 
   container[segment] = [existing, value];
+}
+
+function parseArrayIndex(raw: string, path: string): number {
+  if (!ARRAY_INDEX_PATTERN.test(raw)) {
+    throw new TypeError(`Invalid array index "${raw}" in path "${path}"`);
+  }
+
+  const index = Number(raw);
+  if (!Number.isSafeInteger(index)) {
+    throw new TypeError(`Invalid array index "${raw}" in path "${path}"`);
+  }
+  if (index > MAX_ARRAY_INDEX) {
+    throw new TypeError(`Array index too large in path "${path}": ${index}`);
+  }
+
+  return index;
 }
 
 export function parsePath(path: string): PathSegment[] {
@@ -66,7 +85,7 @@ export function parsePath(path: string): PathSegment[] {
         current += path.slice(i);
         break;
       }
-      segments.push(Number(path.slice(i + 1, close)));
+      segments.push(parseArrayIndex(path.slice(i + 1, close), path));
       i = close + 1;
       // skip trailing dot after bracket (e.g., `[0].name`)
       if (path[i] === ".") i++;

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -80,6 +80,10 @@ describe("parsePath", () => {
     expect(() => parsePath("items[Infinity]")).toThrow("Invalid array index");
   });
 
+  test("rejects non-canonical bracket index", () => {
+    expect(() => parsePath("items[01]")).toThrow("Invalid array index");
+  });
+
   test("rejects pathological bracket index", () => {
     expect(() => parsePath("items[100000000]")).toThrow("Array index too large");
   });

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -72,6 +72,18 @@ describe("parsePath", () => {
     expect(parsePath("items[0]")).toEqual(["items", 0]);
   });
 
+  test("rejects negative bracket index", () => {
+    expect(() => parsePath("items[-1]")).toThrow("Invalid array index");
+  });
+
+  test("rejects non-finite bracket index", () => {
+    expect(() => parsePath("items[Infinity]")).toThrow("Invalid array index");
+  });
+
+  test("rejects pathological bracket index", () => {
+    expect(() => parsePath("items[100000000]")).toThrow("Array index too large");
+  });
+
   test("mixed dot and bracket", () => {
     expect(parsePath("items[0].name")).toEqual(["items", 0, "name"]);
   });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -255,6 +255,10 @@ describe("encode/decode round-trip", () => {
     );
   });
 
+  test("decode rejects array indexes that would create sparse arrays", () => {
+    expect(() => decode([["a[100000000]", "x"]])).toThrow("Array index too large");
+  });
+
   test("object with numeric string keys", () => {
     const input = { "0": "zero", "1": "one", name: "test" };
     const result = roundtrip(input) as Record<string, string>;


### PR DESCRIPTION
## Summary
- Reject invalid bracket indexes during path parsing, including negative, non-finite, non-canonical, and unsafe values.
- Cap decoded array indexes at `100_000` so malicious paths cannot force extremely sparse array allocation.
- Add regression coverage for Issue #8 and parser-level invalid index handling.
- Add a patch changeset for the decode hardening.

Closes #8

## Verification
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
