### PR TITLE
[codex] Reject malformed typed deserializer values

### DIFF
--- a/.changeset/strict-typed-deserializers.md
+++ b/.changeset/strict-typed-deserializers.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Typed deserialization now rejects malformed `Date`, `RegExp`, `number`, and `boolean` wire values instead of silently coercing them, and `decode()` surfaces the failing field path in the error message.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -55,7 +55,12 @@ export function decode<T = unknown>(
     if (typeId && !STRUCTURAL_TYPES.has(typeId)) {
       const handler = getHandler(typeId);
       if (handler) {
-        deserialized.push([path, handler.deserialize(value)]);
+        try {
+          deserialized.push([path, handler.deserialize(value)]);
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : `could not deserialize ${typeId}`;
+          throw new TypeError(`Invalid value for typed field "${path}": ${reason}`);
+        }
         continue;
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export interface TypeHandler<T = unknown> {
 
 type RegisteredTypeHandler = TypeHandler<unknown>;
 
+const NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 function defineTypeHandler<T>(handler: TypeHandler<T>): RegisteredTypeHandler {
   return {
     id: handler.id,
@@ -14,6 +16,43 @@ function defineTypeHandler<T>(handler: TypeHandler<T>): RegisteredTypeHandler {
     serialize: (value) => handler.serialize(value as T),
     deserialize: (raw) => handler.deserialize(raw),
   };
+}
+
+function invalidTypedValue(typeId: string): never {
+  throw new TypeError(`expected ${typeId} metadata-compatible value`);
+}
+
+function deserializeDate(raw: string): Date {
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) invalidTypedValue("Date");
+  return date;
+}
+
+function deserializeRegExp(raw: string): RegExp {
+  if (!raw.startsWith("/")) invalidTypedValue("RegExp");
+
+  const lastSlash = raw.lastIndexOf("/");
+  if (lastSlash <= 0) invalidTypedValue("RegExp");
+
+  try {
+    return new RegExp(raw.slice(1, lastSlash), raw.slice(lastSlash + 1));
+  } catch {
+    invalidTypedValue("RegExp");
+  }
+}
+
+function deserializeNumber(raw: string): number {
+  if (!NUMBER_PATTERN.test(raw)) invalidTypedValue("number");
+
+  const value = Number(raw);
+  if (!Number.isFinite(value)) invalidTypedValue("number");
+  return value;
+}
+
+function deserializeBoolean(raw: string): boolean {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  invalidTypedValue("boolean");
 }
 
 export const typeHandlers: RegisteredTypeHandler[] = [
@@ -57,16 +96,13 @@ export const typeHandlers: RegisteredTypeHandler[] = [
     id: "Date",
     test: (v): v is Date => v instanceof Date,
     serialize: (v) => v.toISOString(),
-    deserialize: (s) => new Date(s),
+    deserialize: deserializeDate,
   }),
   defineTypeHandler({
     id: "RegExp",
     test: (v): v is RegExp => v instanceof RegExp,
     serialize: (v) => v.toString(),
-    deserialize: (s) => {
-      const lastSlash = s.lastIndexOf("/");
-      return new RegExp(s.slice(1, lastSlash), s.slice(lastSlash + 1));
-    },
+    deserialize: deserializeRegExp,
   }),
   defineTypeHandler({
     id: "URL",
@@ -84,13 +120,13 @@ export const typeHandlers: RegisteredTypeHandler[] = [
     id: "number",
     test: (v): v is number => typeof v === "number",
     serialize: (v) => String(v),
-    deserialize: (s) => Number(s),
+    deserialize: deserializeNumber,
   }),
   defineTypeHandler({
     id: "boolean",
     test: (v): v is boolean => typeof v === "boolean",
     serialize: (v) => String(v),
-    deserialize: (s) => s === "true",
+    deserialize: deserializeBoolean,
   }),
   defineTypeHandler({
     id: "null",

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,15 +29,15 @@ function deserializeDate(raw: string): Date {
 }
 
 function deserializeRegExp(raw: string): RegExp {
-  if (!raw.startsWith("/")) invalidTypedValue("RegExp");
+  if (!raw.startsWith("/")) return invalidTypedValue("RegExp");
 
   const lastSlash = raw.lastIndexOf("/");
-  if (lastSlash <= 0) invalidTypedValue("RegExp");
+  if (lastSlash <= 0) return invalidTypedValue("RegExp");
 
   try {
     return new RegExp(raw.slice(1, lastSlash), raw.slice(lastSlash + 1));
   } catch {
-    invalidTypedValue("RegExp");
+    return invalidTypedValue("RegExp");
   }
 }
 
@@ -52,7 +52,7 @@ function deserializeNumber(raw: string): number {
 function deserializeBoolean(raw: string): boolean {
   if (raw === "true") return true;
   if (raw === "false") return false;
-  invalidTypedValue("boolean");
+  return invalidTypedValue("boolean");
 }
 
 export const typeHandlers: RegisteredTypeHandler[] = [

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -134,4 +134,38 @@ describe("type registry", () => {
   test("handler priority: Infinity before number", () => {
     expect(findHandler(Infinity)!.id).toBe("infinity");
   });
+
+  test.each([
+    [
+      "Date",
+      "when",
+      "not-a-date",
+      'Invalid value for typed field "when": expected Date metadata-compatible value',
+    ],
+    [
+      "number",
+      "count",
+      "not-a-number",
+      'Invalid value for typed field "count": expected number metadata-compatible value',
+    ],
+    [
+      "boolean",
+      "active",
+      "yes",
+      'Invalid value for typed field "active": expected boolean metadata-compatible value',
+    ],
+    [
+      "RegExp",
+      "pattern",
+      "unterminated",
+      'Invalid value for typed field "pattern": expected RegExp metadata-compatible value',
+    ],
+  ])("decode rejects malformed %s values", (typeId, path, value, message) => {
+    expect(() =>
+      decode([
+        [path, value],
+        ["$types", JSON.stringify({ [path]: typeId })],
+      ]),
+    ).toThrow(message);
+  });
 });


### PR DESCRIPTION
## Summary
- reject malformed `Date`, `RegExp`, `number`, and `boolean` typed wire values instead of silently coercing them
- wrap typed deserialization failures with the failing field path so decode errors are actionable
- add regression coverage and a patch changeset for the stricter decode behavior

## Why
Issue #9 identified that several typed deserializers in `src/types.ts` were using permissive constructors and coercions. That allowed malformed metadata payloads to become `Invalid Date`, `NaN`, or incorrect boolean values instead of failing clearly during `decode()`.

## User Impact
Malformed typed payloads now throw a `TypeError` during decode with the field path in the message, instead of returning silently corrupted runtime values.

## Root Cause
Built-in typed handlers delegated directly to permissive JavaScript coercions like `new Date(raw)`, `Number(raw)`, and `raw === "true"`, without validating that the incoming string matched a supported serialized representation.

## Validation
- `bun fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`

Closes #9