### PR TITLE
[codex] expose custom type handlers

### DIFF
--- a/.changeset/public-custom-type-handlers.md
+++ b/.changeset/public-custom-type-handlers.md
@@ -1,0 +1,5 @@
+---
+"superformdata": minor
+---
+
+Expose per-call custom type handlers for encoding and decoding domain-specific values.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,34 @@ export async function POST(request: Request) {
 }
 ```
 
+## Custom Type Handlers
+
+Pass custom handlers to `encode()` and `decode()` when you need to round-trip domain-specific values.
+
+```ts
+import { decode, encode, type TypeHandler } from "superformdata";
+
+interface Money {
+  readonly cents: number;
+}
+
+const moneyHandler: TypeHandler<Money> = {
+  id: "Money",
+  test: (value): value is Money =>
+    typeof value === "object" &&
+    value !== null &&
+    "cents" in value &&
+    typeof value.cents === "number",
+  serialize: (value) => String(value.cents),
+  deserialize: (raw) => ({ cents: Number(raw) }),
+};
+
+const entries = encode({ price: { cents: 1299 } }, { typeHandlers: [moneyHandler] });
+const value = decode<{ price: Money }>(entries, { typeHandlers: [moneyHandler] });
+```
+
+Custom handler IDs must be unique and cannot use built-in or structural IDs such as `number`, `Date`, `set`, or `map`.
+
 ## `decodeRequest()`
 
 Decode a `Request` body directly.
@@ -250,9 +278,9 @@ document.querySelector('input[name="homepage"]')?.addEventListener("change", onU
 ## API
 
 ```ts
-encode<T>(input: T, options?: { typesKey?: string; types?: Record<string, string> }): [string, string][]
-decode<T = unknown>(data: FormData | Iterable<[string, FormDataEntryValue]>, options?: { typesKey?: string }): T
-decodeRequest<T = unknown>(request: Request, options?: { typesKey?: string }): Promise<T>
+encode<T>(input: T, options?: { typesKey?: string; types?: Record<string, string>; typeHandlers?: readonly TypeHandler[] }): [string, string][]
+decode<T = unknown>(data: FormData | Iterable<[string, FormDataEntryValue]>, options?: { typesKey?: string; typeHandlers?: readonly TypeHandler[] }): T
+decodeRequest<T = unknown>(request: Request, options?: { typesKey?: string; typeHandlers?: readonly TypeHandler[] }): Promise<T>
 onChange(typeId: string, options?: { typesKey?: string }): (event: Event) => void
 ```
 

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -16,7 +16,7 @@ export function decode<T = unknown>(
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
   const raw: [string, string][] = [];
   let typesJson: string | undefined;
-  const handlers = createTypeRegistry(options?.typeHandlers);
+  const registry = createTypeRegistry(options?.typeHandlers);
 
   for (const [key, value] of data) {
     if (typeof value !== "string") {
@@ -55,7 +55,7 @@ export function decode<T = unknown>(
   for (const [path, value] of raw) {
     const typeId = types[path];
     if (typeId && !STRUCTURAL_TYPES.has(typeId)) {
-      const handler = getHandler(typeId, handlers);
+      const handler = getHandler(typeId, registry);
       if (handler) {
         try {
           deserialized.push([path, handler.deserialize(value)]);

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,11 +1,12 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
 import { appendIndex, appendKey, parsePath, unflatten } from "./path.ts";
-import { getHandler } from "./types.ts";
+import { createTypeRegistry, getHandler, type TypeHandlerList } from "./types.ts";
 
 const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
 
 export interface DecodeOptions {
   typesKey?: string;
+  typeHandlers?: TypeHandlerList;
 }
 
 export function decode<T = unknown>(
@@ -15,6 +16,7 @@ export function decode<T = unknown>(
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
   const raw: [string, string][] = [];
   let typesJson: string | undefined;
+  const handlers = createTypeRegistry(options?.typeHandlers);
 
   for (const [key, value] of data) {
     if (typeof value !== "string") {
@@ -53,7 +55,7 @@ export function decode<T = unknown>(
   for (const [path, value] of raw) {
     const typeId = types[path];
     if (typeId && !STRUCTURAL_TYPES.has(typeId)) {
-      const handler = getHandler(typeId);
+      const handler = getHandler(typeId, handlers);
       if (handler) {
         try {
           deserialized.push([path, handler.deserialize(value)]);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -22,6 +22,7 @@ export interface EncodeOptions {
 
 export function encode<T>(input: T, options?: EncodeOptions): [string, string][] {
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
+  const registry = createTypeRegistry(options?.typeHandlers);
 
   // HTMLFormElement
   if (typeof HTMLFormElement !== "undefined" && input instanceof HTMLFormElement) {
@@ -37,9 +38,8 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
   const entries: [string, string][] = [];
   const types: Record<string, string> = {};
   const seen = new Set<unknown>();
-  const handlers = createTypeRegistry(options?.typeHandlers);
 
-  walk(input, "", entries, types, seen, handlers);
+  walk(input, "", entries, types, seen, registry);
 
   if (Object.keys(types).length > 0) {
     entries.push([typesKey, JSON.stringify(types)]);
@@ -187,14 +187,14 @@ function walk(
   entries: [string, string][],
   types: Record<string, string>,
   seen: Set<unknown>,
-  handlers: ReturnType<typeof createTypeRegistry>,
+  registry: ReturnType<typeof createTypeRegistry>,
 ): void {
   if (value instanceof Set) {
     trackRef(value, path, seen);
     types[path] = "set";
     let i = 0;
     for (const item of value) {
-      walk(item, appendIndex(path, i), entries, types, seen, handlers);
+      walk(item, appendIndex(path, i), entries, types, seen, registry);
       i++;
     }
     seen.delete(value);
@@ -206,8 +206,8 @@ function walk(
     types[path] = "map";
     let i = 0;
     for (const [k, v] of value) {
-      walk(k, appendIndex(appendIndex(path, i), 0), entries, types, seen, handlers);
-      walk(v, appendIndex(appendIndex(path, i), 1), entries, types, seen, handlers);
+      walk(k, appendIndex(appendIndex(path, i), 0), entries, types, seen, registry);
+      walk(v, appendIndex(appendIndex(path, i), 1), entries, types, seen, registry);
       i++;
     }
     seen.delete(value);
@@ -222,13 +222,13 @@ function walk(
       return;
     }
     for (let i = 0; i < value.length; i++) {
-      walk(value[i], appendIndex(path, i), entries, types, seen, handlers);
+      walk(value[i], appendIndex(path, i), entries, types, seen, registry);
     }
     seen.delete(value);
     return;
   }
 
-  const handler = findHandler(value, handlers);
+  const handler = findHandler(value, registry);
   if (handler) {
     entries.push([path, handler.serialize(value)]);
     types[path] = handler.id;
@@ -244,7 +244,7 @@ function walk(
       return;
     }
     for (const key of keys) {
-      walk(value[key], appendKey(path, key), entries, types, seen, handlers);
+      walk(value[key], appendKey(path, key), entries, types, seen, registry);
     }
     seen.delete(value);
     return;

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,11 +1,12 @@
 import { appendIndex, appendKey } from "./path.ts";
-import { findHandler } from "./types.ts";
+import { createTypeRegistry, findHandler, type TypeHandlerList } from "./types.ts";
 
 export const DEFAULT_TYPES_KEY = "$types";
 
 export interface EncodeOptions {
   typesKey?: string;
   types?: Record<string, string>;
+  typeHandlers?: TypeHandlerList;
   /**
    * The element used to submit the form, mirroring `new FormData(form, submitter)`.
    * Only submit buttons (`<button>`, `input[type=submit]`) that equal this element
@@ -36,8 +37,9 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
   const entries: [string, string][] = [];
   const types: Record<string, string> = {};
   const seen = new Set<unknown>();
+  const handlers = createTypeRegistry(options?.typeHandlers);
 
-  walk(input, "", entries, types, seen);
+  walk(input, "", entries, types, seen, handlers);
 
   if (Object.keys(types).length > 0) {
     entries.push([typesKey, JSON.stringify(types)]);
@@ -185,13 +187,14 @@ function walk(
   entries: [string, string][],
   types: Record<string, string>,
   seen: Set<unknown>,
+  handlers: ReturnType<typeof createTypeRegistry>,
 ): void {
   if (value instanceof Set) {
     trackRef(value, path, seen);
     types[path] = "set";
     let i = 0;
     for (const item of value) {
-      walk(item, appendIndex(path, i), entries, types, seen);
+      walk(item, appendIndex(path, i), entries, types, seen, handlers);
       i++;
     }
     seen.delete(value);
@@ -203,8 +206,8 @@ function walk(
     types[path] = "map";
     let i = 0;
     for (const [k, v] of value) {
-      walk(k, appendIndex(appendIndex(path, i), 0), entries, types, seen);
-      walk(v, appendIndex(appendIndex(path, i), 1), entries, types, seen);
+      walk(k, appendIndex(appendIndex(path, i), 0), entries, types, seen, handlers);
+      walk(v, appendIndex(appendIndex(path, i), 1), entries, types, seen, handlers);
       i++;
     }
     seen.delete(value);
@@ -219,9 +222,16 @@ function walk(
       return;
     }
     for (let i = 0; i < value.length; i++) {
-      walk(value[i], appendIndex(path, i), entries, types, seen);
+      walk(value[i], appendIndex(path, i), entries, types, seen, handlers);
     }
     seen.delete(value);
+    return;
+  }
+
+  const handler = findHandler(value, handlers);
+  if (handler) {
+    entries.push([path, handler.serialize(value)]);
+    types[path] = handler.id;
     return;
   }
 
@@ -234,18 +244,14 @@ function walk(
       return;
     }
     for (const key of keys) {
-      walk(value[key], appendKey(path, key), entries, types, seen);
+      walk(value[key], appendKey(path, key), entries, types, seen, handlers);
     }
     seen.delete(value);
     return;
   }
 
   // Leaf value
-  const handler = findHandler(value);
-  if (handler) {
-    entries.push([path, handler.serialize(value)]);
-    types[path] = handler.id;
-  } else if (typeof value === "string") {
+  if (typeof value === "string") {
     entries.push([path, value]);
   } else {
     const type = typeof value === "object" ? (value as object).constructor.name : typeof value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export {
 export type { ChangeHandlerOptions, ChangeHandlers } from "./client.ts";
 export type { EncodeOptions } from "./encode.ts";
 export type { DecodeOptions } from "./decode.ts";
+export type { TypeHandler, TypeHandlerList } from "./types.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export type TypeHandlerList = readonly TypeHandler<any>[];
 
 type RegisteredTypeHandler = TypeHandler<unknown>;
 
+export interface TypeRegistry {
+  readonly handlers: readonly RegisteredTypeHandler[];
+  readonly handlerMap: ReadonlyMap<string, RegisteredTypeHandler>;
+}
+
 const NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
 const RESERVED_TYPE_IDS = new Set(["set", "map", "array", "object"]);
 
@@ -145,11 +150,17 @@ for (const handler of typeHandlers) {
   handlerMap.set(handler.id, handler);
 }
 
-export function createTypeRegistry(customHandlers?: TypeHandlerList): RegisteredTypeHandler[] {
-  if (!customHandlers || customHandlers.length === 0) return typeHandlers;
+const builtInRegistry: TypeRegistry = {
+  handlers: typeHandlers,
+  handlerMap,
+};
+
+export function createTypeRegistry(customHandlers?: TypeHandlerList): TypeRegistry {
+  if (!customHandlers || customHandlers.length === 0) return builtInRegistry;
 
   const seen = new Set<string>();
   const handlers: RegisteredTypeHandler[] = [];
+  const customHandlerMap = new Map(handlerMap);
 
   for (const handler of customHandlers) {
     if (handler.id === "") {
@@ -162,24 +173,28 @@ export function createTypeRegistry(customHandlers?: TypeHandlerList): Registered
       throw new TypeError(`Duplicate custom type handler id "${handler.id}"`);
     }
     seen.add(handler.id);
-    handlers.push(defineTypeHandler(handler));
+    const registeredHandler = defineTypeHandler(handler);
+    handlers.push(registeredHandler);
+    customHandlerMap.set(handler.id, registeredHandler);
   }
 
-  return [...handlers, ...typeHandlers];
+  return {
+    handlers: [...handlers, ...typeHandlers],
+    handlerMap: customHandlerMap,
+  };
 }
 
 export function findHandler(
   value: unknown,
-  handlers: readonly RegisteredTypeHandler[] = typeHandlers,
+  registry: TypeRegistry = builtInRegistry,
 ): RegisteredTypeHandler | undefined {
   if (typeof value === "string") return undefined;
-  return handlers.find((h) => h.test(value));
+  return registry.handlers.find((h) => h.test(value));
 }
 
 export function getHandler(
   id: string,
-  handlers: readonly RegisteredTypeHandler[] = typeHandlers,
+  registry: TypeRegistry = builtInRegistry,
 ): RegisteredTypeHandler | undefined {
-  if (handlers === typeHandlers) return handlerMap.get(id);
-  return handlers.find((handler) => handler.id === id);
+  return registry.handlerMap.get(id);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,16 @@
 export interface TypeHandler<T = unknown> {
-  id: string;
-  test: (value: unknown) => value is T;
-  serialize: (value: T) => string;
-  deserialize: (raw: string) => T;
+  readonly id: string;
+  readonly test: (value: unknown) => value is T;
+  readonly serialize: (value: T) => string;
+  readonly deserialize: (raw: string) => T;
 }
+
+export type TypeHandlerList = readonly TypeHandler<any>[];
 
 type RegisteredTypeHandler = TypeHandler<unknown>;
 
 const NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+const RESERVED_TYPE_IDS = new Set(["set", "map", "array", "object"]);
 
 function defineTypeHandler<T>(handler: TypeHandler<T>): RegisteredTypeHandler {
   return {
@@ -136,16 +139,47 @@ export const typeHandlers: RegisteredTypeHandler[] = [
   }),
 ];
 
+const builtInTypeIds = new Set(typeHandlers.map((handler) => handler.id));
 const handlerMap = new Map<string, RegisteredTypeHandler>();
 for (const handler of typeHandlers) {
   handlerMap.set(handler.id, handler);
 }
 
-export function findHandler(value: unknown): RegisteredTypeHandler | undefined {
-  if (typeof value === "string") return undefined;
-  return typeHandlers.find((h) => h.test(value));
+export function createTypeRegistry(customHandlers?: TypeHandlerList): RegisteredTypeHandler[] {
+  if (!customHandlers || customHandlers.length === 0) return typeHandlers;
+
+  const seen = new Set<string>();
+  const handlers: RegisteredTypeHandler[] = [];
+
+  for (const handler of customHandlers) {
+    if (handler.id === "") {
+      throw new TypeError("Custom type handler id must not be empty");
+    }
+    if (RESERVED_TYPE_IDS.has(handler.id) || builtInTypeIds.has(handler.id)) {
+      throw new TypeError(`Custom type handler id "${handler.id}" is reserved`);
+    }
+    if (seen.has(handler.id)) {
+      throw new TypeError(`Duplicate custom type handler id "${handler.id}"`);
+    }
+    seen.add(handler.id);
+    handlers.push(defineTypeHandler(handler));
+  }
+
+  return [...handlers, ...typeHandlers];
 }
 
-export function getHandler(id: string): RegisteredTypeHandler | undefined {
-  return handlerMap.get(id);
+export function findHandler(
+  value: unknown,
+  handlers: readonly RegisteredTypeHandler[] = typeHandlers,
+): RegisteredTypeHandler | undefined {
+  if (typeof value === "string") return undefined;
+  return handlers.find((h) => h.test(value));
+}
+
+export function getHandler(
+  id: string,
+  handlers: readonly RegisteredTypeHandler[] = typeHandlers,
+): RegisteredTypeHandler | undefined {
+  if (handlers === typeHandlers) return handlerMap.get(id);
+  return handlers.find((handler) => handler.id === id);
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { decode } from "../src/decode.ts";
 import { encode } from "../src/encode.ts";
+import type { TypeHandler } from "../src/types.ts";
 import {
   createChangeHandlers,
   onBigIntChange,
@@ -24,6 +25,13 @@ function createForm(html: string): HTMLFormElement {
   document.body.innerHTML = `<form>${html}</form>`;
   return document.querySelector("form")!;
 }
+
+const invalidTypeHandler: TypeHandler<unknown> = {
+  id: "number",
+  test: (value): value is unknown => value !== undefined,
+  serialize: String,
+  deserialize: (raw) => raw,
+};
 
 // --- onChange handlers ---
 
@@ -278,6 +286,14 @@ describe("encode(form)", () => {
     expect(entries.find(([k]) => k === "$types")).toBeUndefined();
   });
 
+  test("validates custom type handlers for form inputs", () => {
+    const form = createForm('<input name="count" value="42" />');
+
+    expect(() => encode(form, { typeHandlers: [invalidTypeHandler] })).toThrow(
+      'Custom type handler id "number" is reserved',
+    );
+  });
+
   test("excludes button elements by default (no submitter)", () => {
     const form = createForm(
       '<input name="title" value="hello" /><button name="action" value="save">Save</button>',
@@ -415,6 +431,15 @@ describe("encode(FormData)", () => {
       ["name", "Alice"],
       ["city", "NYC"],
     ]);
+  });
+
+  test("validates custom type handlers for FormData inputs", () => {
+    const fd = new FormData();
+    fd.append("count", "42");
+
+    expect(() => encode(fd, { typeHandlers: [invalidTypeHandler] })).toThrow(
+      'Custom type handler id "number" is reserved',
+    );
   });
 
   test("encode(FormData) round-trips through decode", () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { decode, decodeRequest, encode } from "../src/index.ts";
+import { decode, decodeRequest, encode, type TypeHandler } from "../src/index.ts";
 import { findHandler, getHandler } from "../src/types.ts";
 
 type Assert<T extends true> = T;
@@ -46,6 +46,21 @@ async function assertDecodeRequestGeneric(): Promise<void> {
 }
 
 void assertDecodeRequestGeneric;
+
+interface Money {
+  readonly cents: number;
+}
+
+const moneyHandler: TypeHandler<Money> = {
+  id: "Money",
+  test: (value): value is Money =>
+    typeof value === "object" &&
+    value !== null &&
+    "cents" in value &&
+    typeof value.cents === "number",
+  serialize: (value) => String(value.cents),
+  deserialize: (raw) => ({ cents: Number(raw) }),
+};
 
 describe("type registry", () => {
   test("findHandler returns undefined for strings", () => {
@@ -167,5 +182,52 @@ describe("type registry", () => {
         ["$types", JSON.stringify({ [path]: typeId })],
       ]),
     ).toThrow(message);
+  });
+
+  test("custom type handlers round-trip domain values per call", () => {
+    const encoded = encode({ price: { cents: 1234 } }, { typeHandlers: [moneyHandler] });
+
+    expect(encoded).toEqual([
+      ["price", "1234"],
+      ["$types", JSON.stringify({ price: "Money" })],
+    ]);
+    expect(decode<{ price: Money }>(encoded, { typeHandlers: [moneyHandler] })).toEqual({
+      price: { cents: 1234 },
+    });
+  });
+
+  test("custom type handlers decode explicitly typed entries", () => {
+    expect(
+      decode<{ price: Money }>(
+        [
+          ["price", "500"],
+          ["$types", JSON.stringify({ price: "Money" })],
+        ],
+        { typeHandlers: [moneyHandler] },
+      ),
+    ).toEqual({ price: { cents: 500 } });
+  });
+
+  test("custom type handler ids cannot collide with built-in or structural ids", () => {
+    expect(() => encode(1, { typeHandlers: [{ ...moneyHandler, id: "number" }] })).toThrow(
+      'Custom type handler id "number" is reserved',
+    );
+    expect(() => encode(1, { typeHandlers: [{ ...moneyHandler, id: "map" }] })).toThrow(
+      'Custom type handler id "map" is reserved',
+    );
+  });
+
+  test("custom type handler ids must be unique and non-empty", () => {
+    expect(() => encode(1, { typeHandlers: [{ ...moneyHandler, id: "" }] })).toThrow(
+      "Custom type handler id must not be empty",
+    );
+    expect(() =>
+      encode(1, {
+        typeHandlers: [
+          { ...moneyHandler, id: "Money" },
+          { ...moneyHandler, id: "Money" },
+        ],
+      }),
+    ).toThrow('Duplicate custom type handler id "Money"');
   });
 });


### PR DESCRIPTION
## Summary

Closes #10.

Adds a public per-call custom type handler API so callers can serialize and deserialize domain-specific values without patching the package internals or mutating the built-in registry.

## Changes

- Add `typeHandlers` options to `encode()`, `decode()`, and `decodeRequest()`.
- Export `TypeHandler` and `TypeHandlerList` from the public entrypoint.
- Validate custom handler IDs so they cannot be empty, duplicated, or collide with built-in/structural metadata IDs.
- Let custom handlers claim non-structural object values before plain-object traversal, while preserving `Set`, `Map`, and array structural handling.
- Document custom handler usage in the README.
- Add a changeset for the new public API.

## Impact

Consumers can now round-trip domain objects such as money, decimal, or application-specific value classes by passing the same handler list to encode and decode calls. Existing built-in serialization remains unchanged when no custom handlers are provided.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`