### PR TITLE
[codex] Prevent decode prototype pollution

### DIFF
--- a/.changeset/secure-decode-paths.md
+++ b/.changeset/secure-decode-paths.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject unsafe decoded path segments such as `__proto__`, `prototype`, and `constructor` to prevent prototype pollution during `decode()`.

--- a/src/path.ts
+++ b/src/path.ts
@@ -17,9 +17,17 @@ export function appendIndex(path: string, index: number): string {
 
 const MAX_ARRAY_INDEX = 100_000;
 const ARRAY_INDEX_PATTERN = /^(?:0|[1-9]\d*)$/;
+const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
 export type PathSegment = string | number;
 type PathContainer = Record<string | number, unknown>;
+
+function assertSafePathSegment(segment: PathSegment, path: string): void {
+  if (typeof segment === "number") return;
+  if (!UNSAFE_OBJECT_KEYS.has(segment)) return;
+
+  throw new TypeError(`Unsafe path segment "${segment}" in path "${path}"`);
+}
 
 function assignPathValue(container: PathContainer, segment: PathSegment, value: unknown): void {
   const existing = container[segment];
@@ -109,6 +117,9 @@ export function unflatten(entries: [string, unknown][]): unknown {
   for (const [path, value] of entries) {
     const segments = parsePath(path);
     if (segments.length === 0) continue;
+    for (const segment of segments) {
+      assertSafePathSegment(segment, path);
+    }
 
     let current: PathContainer = root;
 

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -189,4 +189,16 @@ describe("unflatten", () => {
       ]),
     ).toEqual({ user: { tags: ["a", "b"] } });
   });
+
+  test("rejects path segments that can mutate object prototypes", () => {
+    expect(() => unflatten([["__proto__.polluted", "yes"]])).toThrow(
+      'Unsafe path segment "__proto__"',
+    );
+    expect(() => unflatten([["constructor.prototype.polluted", "yes"]])).toThrow(
+      'Unsafe path segment "constructor"',
+    );
+    expect(() => unflatten([["prototype.polluted", "yes"]])).toThrow(
+      'Unsafe path segment "prototype"',
+    );
+  });
 });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -355,6 +355,13 @@ describe("encode/decode round-trip", () => {
     expect(decode<Record<string, never>>([])).toEqual({});
   });
 
+  test("decode rejects prototype pollution path segments", () => {
+    expect(() => decode([["__proto__.polluted", "yes"]])).toThrow(
+      'Unsafe path segment "__proto__"',
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   test("decode throws on malformed $types JSON", () => {
     expect(() =>
       decode([


### PR DESCRIPTION
## Summary

Fixes #22 by rejecting decoded path segments that can mutate JavaScript object prototypes during `unflatten()` path assignment.

`decode()` accepts form-style entry keys and reconstructs nested containers from those paths. Before this change, segments like `__proto__` could be traversed or assigned through normal object semantics, allowing malicious input such as `__proto__.polluted=yes` to affect unrelated objects in the process.

## Changes

- Added a path-segment safety check in `unflatten()` for `__proto__`, `prototype`, and `constructor` before any traversal or assignment occurs.
- Added regression coverage for both `unflatten()` and public `decode()` behavior.
- Added a patch changeset documenting the security fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run check`
