### PR TITLE
[codex] Validate decoded $types metadata

### DIFF
--- a/.changeset/validate-types-metadata.md
+++ b/.changeset/validate-types-metadata.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Validate decoded `$types` metadata so malformed object shapes and non-string type ids fail with clear `TypeError` messages.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -40,6 +40,7 @@ export function decode<T = unknown>(
         `Invalid superformdata metadata: "${typesKey}" field contains malformed JSON`,
       );
     }
+    validateTypesMetadata(types, typesKey);
   }
 
   // Collect structural type paths and empty container paths
@@ -113,6 +114,23 @@ export function decode<T = unknown>(
   }
 
   return result as T;
+}
+
+function validateTypesMetadata(
+  types: unknown,
+  typesKey: string,
+): asserts types is Record<string, string> {
+  if (types === null || typeof types !== "object" || Array.isArray(types)) {
+    throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be an object`);
+  }
+
+  for (const [path, typeId] of Object.entries(types)) {
+    if (typeof typeId !== "string") {
+      throw new TypeError(
+        `Invalid superformdata metadata: "${typesKey}" field must map paths to string type ids (path: "${path}")`,
+      );
+    }
+  }
 }
 
 function buildParentPathSet(paths: Set<string>): Set<string> {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -371,6 +371,28 @@ describe("encode/decode round-trip", () => {
     ).toThrow("malformed JSON");
   });
 
+  test("decode throws on non-object $types metadata", () => {
+    const invalidMetadata = ["null", "[]", '"string"', "42", "true"];
+
+    for (const metadata of invalidMetadata) {
+      expect(() =>
+        decode([
+          ["name", "Alice"],
+          ["$types", metadata],
+        ]),
+      ).toThrow("must be an object");
+    }
+  });
+
+  test("decode throws on non-string $types metadata values", () => {
+    expect(() =>
+      decode([
+        ["age", "30"],
+        ["$types", JSON.stringify({ age: 30 })],
+      ]),
+    ).toThrow("must map paths to string type ids");
+  });
+
   test("decode throws on File entries in FormData", () => {
     const formData = new FormData();
     formData.append("name", "Alice");


### PR DESCRIPTION
## Summary

Fixes #23.

This validates parsed `$types` metadata before `decode()` uses it. Malformed-but-valid JSON such as `null`, arrays, primitives, and metadata entries with non-string type ids now fail with clear `TypeError` messages instead of crashing later or being silently accepted.

## Root Cause

`decode()` parsed the `$types` field with `JSON.parse()` and immediately treated the result as `Record<string, string>`. That allowed invalid JSON values such as `null` to reach `Object.entries()` and allowed object values like `{ age: 30 }` to be consumed as if they were valid metadata.

## Changes

- Added `$types` metadata shape validation after parsing.
- Reject non-object metadata, arrays, primitives, and non-string type ids with metadata-specific `TypeError`s.
- Added regression tests for the Issue #23 cases.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test test/roundtrip.test.ts`
- `bun run test`
- `bun typecheck`
- `bun lint`
