### PR TITLE
[codex] Reject unknown decode type ids

### DIFF
--- a/.changeset/reject-unknown-type-ids.md
+++ b/.changeset/reject-unknown-type-ids.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject unknown `$types` metadata ids during `decode()` instead of silently returning raw string values.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -62,10 +62,7 @@ export function decode<T = unknown>(
   for (const [path, value] of raw) {
     const typeId = types[path];
     if (typeId && !STRUCTURAL_TYPES.has(typeId)) {
-      const handler = getHandler(typeId, registry);
-      if (!handler) {
-        throw new TypeError(`Unknown type id "${typeId}" for typed field "${path}"`);
-      }
+      const handler = getHandler(typeId, registry)!;
       try {
         deserialized.push([path, handler.deserialize(value)]);
       } catch (error) {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,6 +1,11 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
 import { appendIndex, appendKey, parsePath, unflatten } from "./path.ts";
-import { createTypeRegistry, getHandler, type TypeHandlerList } from "./types.ts";
+import {
+  createTypeRegistry,
+  getHandler,
+  type TypeHandlerList,
+  type TypeRegistry,
+} from "./types.ts";
 
 const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
 
@@ -41,6 +46,7 @@ export function decode<T = unknown>(
       );
     }
     validateTypesMetadata(types, typesKey);
+    validateKnownTypeIds(types, registry);
   }
 
   // Collect structural type paths and empty container paths
@@ -57,15 +63,16 @@ export function decode<T = unknown>(
     const typeId = types[path];
     if (typeId && !STRUCTURAL_TYPES.has(typeId)) {
       const handler = getHandler(typeId, registry);
-      if (handler) {
-        try {
-          deserialized.push([path, handler.deserialize(value)]);
-        } catch (error) {
-          const reason = error instanceof Error ? error.message : `could not deserialize ${typeId}`;
-          throw new TypeError(`Invalid value for typed field "${path}": ${reason}`);
-        }
-        continue;
+      if (!handler) {
+        throw new TypeError(`Unknown type id "${typeId}" for typed field "${path}"`);
       }
+      try {
+        deserialized.push([path, handler.deserialize(value)]);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : `could not deserialize ${typeId}`;
+        throw new TypeError(`Invalid value for typed field "${path}": ${reason}`);
+      }
+      continue;
     }
     deserialized.push([path, value]);
   }
@@ -130,6 +137,15 @@ function validateTypesMetadata(
         `Invalid superformdata metadata: "${typesKey}" field must map paths to string type ids (path: "${path}")`,
       );
     }
+  }
+}
+
+function validateKnownTypeIds(types: Record<string, string>, registry: TypeRegistry): void {
+  for (const [path, typeId] of Object.entries(types)) {
+    if (STRUCTURAL_TYPES.has(typeId)) continue;
+    if (getHandler(typeId, registry)) continue;
+
+    throw new TypeError(`Unknown type id "${typeId}" for typed field "${path}"`);
   }
 }
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -209,6 +209,24 @@ describe("type registry", () => {
     ).toEqual({ price: { cents: 500 } });
   });
 
+  test("decode rejects unregistered custom type ids in metadata", () => {
+    expect(() =>
+      decode([
+        ["price", "500"],
+        ["$types", JSON.stringify({ price: "Money" })],
+      ]),
+    ).toThrow('Unknown type id "Money" for typed field "price"');
+  });
+
+  test("decode rejects typoed built-in type ids in metadata", () => {
+    expect(() =>
+      decode([
+        ["createdAt", "2024-01-01T00:00:00.000Z"],
+        ["$types", JSON.stringify({ createdAt: "date" })],
+      ]),
+    ).toThrow('Unknown type id "date" for typed field "createdAt"');
+  });
+
   test("custom type handler ids cannot collide with built-in or structural ids", () => {
     expect(() => encode(1, { typeHandlers: [{ ...moneyHandler, id: "number" }] })).toThrow(
       'Custom type handler id "number" is reserved',


### PR DESCRIPTION
## Summary

Fixes #24.

`decode()` now validates `$types` metadata against the active type registry before decoding values. Unknown non-structural type ids, including missing custom handlers and typoed built-in ids, now throw a clear `TypeError` instead of silently returning raw strings.

## Root Cause

The leaf deserialization path called `getHandler(typeId, registry)` and only deserialized when a handler existed. If no handler was registered for the metadata id, decode fell through to the raw string path as if no metadata existed.

## Changes

- Validate all parsed `$types` ids against structural ids and the active type registry.
- Keep malformed typed-value errors unchanged for registered handlers.
- Add regression coverage for an unregistered custom `Money` type and a typoed built-in `date` id.
- Add a patch changeset for the decode behavior fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun test`
- `bun typecheck`
