### PR TITLE
[codex] Reject path collisions during decode

### DIFF
--- a/.changeset/clear-pandas-detect.md
+++ b/.changeset/clear-pandas-detect.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject ambiguous scalar/container path collisions during decode with a clear TypeError.

--- a/src/path.ts
+++ b/src/path.ts
@@ -56,14 +56,31 @@ function isObject(value: unknown): value is object {
   return (typeof value === "object" && value !== null) || typeof value === "function";
 }
 
-function assertNotPathCollision(
+function assertNotContainerOverwrite(
   value: unknown,
   containers: WeakSet<object>,
-  collisionPath: string,
   path: string,
 ): void {
   if (isObject(value) && containers.has(value)) {
+    throw new TypeError(`Path collision at "${path}": cannot overwrite existing container`);
+  }
+}
+
+function assertCompatibleContainer(
+  value: unknown,
+  containers: WeakSet<object>,
+  nextSegment: PathSegment,
+  collisionPath: string,
+  path: string,
+): void {
+  if (!isObject(value) || !containers.has(value)) {
     throw new TypeError(`Path collision at "${collisionPath}" while decoding path "${path}"`);
+  }
+
+  if (Array.isArray(value) !== (typeof nextSegment === "number")) {
+    throw new TypeError(
+      `Path collision at "${collisionPath}" while decoding path "${path}": incompatible container type`,
+    );
   }
 }
 
@@ -154,16 +171,20 @@ export function unflatten(entries: [string, unknown][]): unknown {
         const nextContainer = (typeof nextSeg === "number" ? [] : {}) as PathContainer;
         current[seg] = nextContainer;
         containers.add(nextContainer);
-      } else if (!isObject(current[seg]) || !containers.has(current[seg])) {
-        throw new TypeError(
-          `Path collision at "${formatPath(segments.slice(0, i + 1))}" while decoding path "${path}"`,
+      } else {
+        assertCompatibleContainer(
+          current[seg],
+          containers,
+          nextSeg,
+          formatPath(segments.slice(0, i + 1)),
+          path,
         );
       }
       current = current[seg] as PathContainer;
     }
 
     const lastSeg = segments[segments.length - 1]!;
-    assertNotPathCollision(current[lastSeg], containers, formatPath(segments), path);
+    assertNotContainerOverwrite(current[lastSeg], containers, path);
     assignPathValue(current, lastSeg, value);
   }
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -45,6 +45,28 @@ function assignPathValue(container: PathContainer, segment: PathSegment, value: 
   container[segment] = [existing, value];
 }
 
+function formatPath(segments: PathSegment[]): string {
+  return segments.reduce<string>((path, segment) => {
+    if (typeof segment === "number") return appendIndex(path, segment);
+    return appendKey(path, segment);
+  }, "");
+}
+
+function isObject(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+function assertNotPathCollision(
+  value: unknown,
+  containers: WeakSet<object>,
+  collisionPath: string,
+  path: string,
+): void {
+  if (isObject(value) && containers.has(value)) {
+    throw new TypeError(`Path collision at "${collisionPath}" while decoding path "${path}"`);
+  }
+}
+
 function parseArrayIndex(raw: string, path: string): number {
   if (!ARRAY_INDEX_PATTERN.test(raw)) {
     throw new TypeError(`Invalid array index "${raw}" in path "${path}"`);
@@ -113,6 +135,7 @@ export function unflatten(entries: [string, unknown][]): unknown {
 
   const firstPath = entries[0]![0];
   const root = (firstPath.startsWith("[") ? [] : {}) as PathContainer;
+  const containers = new WeakSet<object>([root]);
 
   for (const [path, value] of entries) {
     const segments = parsePath(path);
@@ -128,12 +151,19 @@ export function unflatten(entries: [string, unknown][]): unknown {
       const nextSeg = segments[i + 1]!;
 
       if (current[seg] === undefined) {
-        current[seg] = (typeof nextSeg === "number" ? [] : {}) as PathContainer;
+        const nextContainer = (typeof nextSeg === "number" ? [] : {}) as PathContainer;
+        current[seg] = nextContainer;
+        containers.add(nextContainer);
+      } else if (!isObject(current[seg]) || !containers.has(current[seg])) {
+        throw new TypeError(
+          `Path collision at "${formatPath(segments.slice(0, i + 1))}" while decoding path "${path}"`,
+        );
       }
       current = current[seg] as PathContainer;
     }
 
     const lastSeg = segments[segments.length - 1]!;
+    assertNotPathCollision(current[lastSeg], containers, formatPath(segments), path);
     assignPathValue(current, lastSeg, value);
   }
 

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -190,6 +190,42 @@ describe("unflatten", () => {
     ).toEqual({ user: { tags: ["a", "b"] } });
   });
 
+  test("rejects scalar before object path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a", "x"],
+        ["a.b", "y"],
+      ]),
+    ).toThrow('Path collision at "a" while decoding path "a.b"');
+  });
+
+  test("rejects object before scalar path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a.b", "y"],
+        ["a", "x"],
+      ]),
+    ).toThrow('Path collision at "a" while decoding path "a"');
+  });
+
+  test("rejects scalar before array path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a", "x"],
+        ["a[0]", "y"],
+      ]),
+    ).toThrow('Path collision at "a" while decoding path "a[0]"');
+  });
+
+  test("rejects array before scalar path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a[0]", "y"],
+        ["a", "x"],
+      ]),
+    ).toThrow('Path collision at "a" while decoding path "a"');
+  });
+
   test("rejects path segments that can mutate object prototypes", () => {
     expect(() => unflatten([["__proto__.polluted", "yes"]])).toThrow(
       'Unsafe path segment "__proto__"',

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -205,7 +205,7 @@ describe("unflatten", () => {
         ["a.b", "y"],
         ["a", "x"],
       ]),
-    ).toThrow('Path collision at "a" while decoding path "a"');
+    ).toThrow('Path collision at "a": cannot overwrite existing container');
   });
 
   test("rejects scalar before array path collisions", () => {
@@ -223,7 +223,25 @@ describe("unflatten", () => {
         ["a[0]", "y"],
         ["a", "x"],
       ]),
-    ).toThrow('Path collision at "a" while decoding path "a"');
+    ).toThrow('Path collision at "a": cannot overwrite existing container');
+  });
+
+  test("rejects array before object path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a[0]", "x"],
+        ["a.b", "y"],
+      ]),
+    ).toThrow('Path collision at "a" while decoding path "a.b": incompatible container type');
+  });
+
+  test("rejects object before array path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a.b", "x"],
+        ["a[0]", "y"],
+      ]),
+    ).toThrow('Path collision at "a" while decoding path "a[0]": incompatible container type');
   });
 
   test("rejects path segments that can mutate object prototypes", () => {


### PR DESCRIPTION
## Summary

Fixes #25 by making `decode()` reject ambiguous scalar/container path collisions consistently while unflattening entries.

## Root cause

`unflatten()` created nested containers lazily but did not track whether an existing path segment was a decoder-created container or a leaf value. That meant payloads like `a` followed by `a.b` could attempt to assign through a scalar and throw a low-level runtime error, while the reverse order could turn the container and scalar into an order-dependent array.

## Changes

- Track containers created by `unflatten()` in a `WeakSet`.
- Reject attempts to traverse through non-container leaf values with a clear `TypeError`.
- Reject attempts to assign a leaf value over an existing decoder-created container.
- Preserve existing repeated leaf-key behavior, where identical paths still decode as arrays.
- Add regression tests for scalar-before-object, object-before-scalar, scalar-before-array, and array-before-scalar collisions.
- Add a patch changeset for the behavior fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`
