### PR TITLE
[codex] Fix path-aware invalid Date encode errors

### DIFF
--- a/.changeset/invalid-dates-path.md
+++ b/.changeset/invalid-dates-path.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Report invalid Date values during encode with a path-aware TypeError.

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -230,6 +230,9 @@ function walk(
 
   const handler = findHandler(value, registry);
   if (handler) {
+    if (value instanceof Date && Number.isNaN(value.getTime())) {
+      throw new TypeError(`Invalid Date at path "${path}"`);
+    }
     entries.push([path, handler.serialize(value)]);
     types[path] = handler.id;
     return;

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -230,7 +230,7 @@ function walk(
 
   const handler = findHandler(value, registry);
   if (handler) {
-    if (value instanceof Date && Number.isNaN(value.getTime())) {
+    if (handler.id === "Date" && Number.isNaN((value as Date).getTime())) {
       throw new TypeError(`Invalid Date at path "${path}"`);
     }
     entries.push([path, handler.serialize(value)]);

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -211,6 +211,16 @@ describe("encode/decode round-trip", () => {
     expect(result.toISOString()).toBe("2024-01-01T00:00:00.000Z");
   });
 
+  test("top-level invalid Date throws path-aware TypeError", () => {
+    expect(() => encode(new Date("not-a-date"))).toThrow(new TypeError('Invalid Date at path ""'));
+  });
+
+  test("nested invalid Date throws path-aware TypeError", () => {
+    expect(() => encode({ post: { publishedAt: new Date("not-a-date") } })).toThrow(
+      new TypeError('Invalid Date at path "post.publishedAt"'),
+    );
+  });
+
   test("top-level boolean", () => {
     expect(roundtrip(true)).toBe(true);
     expect(roundtrip(false)).toBe(false);

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -197,6 +197,22 @@ describe("type registry", () => {
     });
   });
 
+  test("custom type handlers can serialize invalid Dates", () => {
+    const invalidDateHandler: TypeHandler<Date> = {
+      id: "InvalidDateSentinel",
+      test: (value): value is Date => value instanceof Date,
+      serialize: (value) => (Number.isNaN(value.getTime()) ? "invalid" : value.toISOString()),
+      deserialize: (raw) => (raw === "invalid" ? new Date("not-a-date") : new Date(raw)),
+    };
+
+    expect(
+      encode({ publishedAt: new Date("not-a-date") }, { typeHandlers: [invalidDateHandler] }),
+    ).toEqual([
+      ["publishedAt", "invalid"],
+      ["$types", JSON.stringify({ publishedAt: "InvalidDateSentinel" })],
+    ]);
+  });
+
   test("custom type handlers decode explicitly typed entries", () => {
     expect(
       decode<{ price: Money }>(


### PR DESCRIPTION
## Summary

Fixes #26.

Encoding an invalid `Date` previously reached the built-in Date serializer and let `Date.prototype.toISOString()` throw a raw `RangeError: Invalid Date`. That error did not include the field path, unlike the rest of the encoder's unsupported-value errors.

This change detects invalid `Date` instances before serialization and throws a `TypeError` in the form `Invalid Date at path "..."`. It covers both top-level values, where the path is `""`, and nested object paths such as `"post.publishedAt"`.

## Impact

Callers now get actionable path-aware diagnostics when payload construction includes a bad date, which makes form/debug flows easier to trace. Valid Date serialization is unchanged.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`

## Changeset

Included a patch changeset: `.changeset/invalid-dates-path.md`.
