### PR TITLE
fix: align form encoding with disabled fieldset semantics

### DIFF
--- a/.changeset/quiet-fieldsets-encode.md
+++ b/.changeset/quiet-fieldsets-encode.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Skip form controls disabled by ancestor fieldsets during form encoding, while preserving the native first-legend exception.

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -59,10 +59,7 @@ function isSubmitButton(el: Element): boolean {
 }
 
 function isInsideFirstLegend(element: Element, fieldset: HTMLFieldSetElement): boolean {
-  const firstLegend = Array.from(fieldset.children).find(
-    (child): child is HTMLLegendElement => child instanceof HTMLLegendElement,
-  );
-
+  const firstLegend = fieldset.querySelector(":scope > legend");
   return firstLegend?.contains(element) ?? false;
 }
 

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -58,6 +58,24 @@ function isSubmitButton(el: Element): boolean {
   return false;
 }
 
+function isInsideFirstLegend(element: Element, fieldset: HTMLFieldSetElement): boolean {
+  const firstLegend = Array.from(fieldset.children).find(
+    (child): child is HTMLLegendElement => child instanceof HTMLLegendElement,
+  );
+
+  return firstLegend?.contains(element) ?? false;
+}
+
+function isDisabledByFieldset(element: Element): boolean {
+  for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+    if (!(parent instanceof HTMLFieldSetElement) || !parent.disabled) continue;
+    const fieldset = parent;
+    if (!isInsideFirstLegend(element, fieldset)) return true;
+  }
+
+  return false;
+}
+
 function encodeForm(
   form: HTMLFormElement,
   typesKey: string,
@@ -69,7 +87,7 @@ function encodeForm(
 
   for (const element of form.elements) {
     const el = element as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
-    if (!el.name || el.disabled) continue;
+    if (!el.name || el.disabled || isDisabledByFieldset(el)) continue;
     if (el.name === typesKey) continue;
 
     // Buttons are only successful controls when they are the submitter

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -264,6 +264,23 @@ describe("encode(form)", () => {
     expect(entries).toEqual([["name", "Alice"]]);
   });
 
+  test("skips controls in disabled fieldsets except controls in the first legend", () => {
+    const form = createForm(
+      "<fieldset disabled>" +
+        '<legend><input name="legend" value="included" /></legend>' +
+        '<input name="secret" value="x" />' +
+        '<legend><input name="secondLegend" value="excluded" /></legend>' +
+        "</fieldset>" +
+        '<input name="name" value="Alice" />',
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([
+      ["legend", "included"],
+      ["name", "Alice"],
+    ]);
+  });
+
   test("handles radio buttons (only checked)", () => {
     const form = createForm(
       '<input name="color" type="radio" value="red" />' +

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -281,6 +281,45 @@ describe("encode(form)", () => {
     ]);
   });
 
+  test("skips controls in nested fieldsets inside disabled fieldset bodies", () => {
+    const form = createForm(
+      "<fieldset disabled>" +
+        '<legend><input name="outerLegend" value="included" /></legend>' +
+        "<fieldset>" +
+        '<legend><input name="innerLegend" value="excluded" /></legend>' +
+        '<input name="innerBody" value="excluded" />' +
+        "</fieldset>" +
+        "</fieldset>" +
+        '<input name="name" value="Alice" />',
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([
+      ["outerLegend", "included"],
+      ["name", "Alice"],
+    ]);
+  });
+
+  test("preserves first-legend exceptions across nested disabled fieldsets", () => {
+    const form = createForm(
+      "<fieldset disabled>" +
+        "<legend>" +
+        '<input name="outerLegend" value="included" />' +
+        "<fieldset disabled>" +
+        '<legend><input name="innerLegend" value="included" /></legend>' +
+        '<input name="innerBody" value="excluded" />' +
+        "</fieldset>" +
+        "</legend>" +
+        "</fieldset>",
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([
+      ["outerLegend", "included"],
+      ["innerLegend", "included"],
+    ]);
+  });
+
   test("handles radio buttons (only checked)", () => {
     const form = createForm(
       '<input name="color" type="radio" value="red" />' +


### PR DESCRIPTION
## Summary

Fixes #27.

`encode(form)` now follows native successful-control behavior for disabled fieldsets more closely. Controls inside disabled fieldsets are skipped unless they are inside that fieldset's first `<legend>`, matching the browser exception for legend controls.

## Root Cause

The form encoder only checked each control's direct `disabled` property. Native form submission also treats controls as disabled when they are descendants of a disabled `<fieldset>`, except for controls inside the first legend of that fieldset.

## Changes

- Added disabled-fieldset ancestor detection in `encodeForm()`.
- Preserved the native first-legend exception.
- Added a browser-form regression test covering skipped fieldset controls and included first-legend controls.
- Added a patch changeset for the fix.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`
