### PR TITLE
[codex] Preserve sparse array holes

### DIFF
--- a/.changeset/preserve-sparse-array-holes.md
+++ b/.changeset/preserve-sparse-array-holes.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Preserve sparse array holes during encode/decode round trips instead of densifying them as explicit `undefined` values.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
-import { appendIndex, appendKey, parsePath, unflatten } from "./path.ts";
+import { MAX_SPARSE_ARRAY_LENGTH, appendIndex, appendKey, parsePath, unflatten } from "./path.ts";
 import {
   createTypeRegistry,
   getHandler,
@@ -8,7 +8,6 @@ import {
 } from "./types.ts";
 
 const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
-const MAX_ARRAY_LENGTH = 100_000;
 
 export interface DecodeOptions {
   typesKey?: string;
@@ -179,7 +178,7 @@ function parseSparseArrayTypeId(typeId: string): number | undefined {
   if (!/^(?:0|[1-9]\d*)$/.test(rawLength)) return undefined;
 
   const length = Number(rawLength);
-  if (!Number.isSafeInteger(length) || length > MAX_ARRAY_LENGTH) return undefined;
+  if (!Number.isSafeInteger(length) || length > MAX_SPARSE_ARRAY_LENGTH) return undefined;
 
   return length;
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -8,6 +8,7 @@ import {
 } from "./types.ts";
 
 const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
+const MAX_ARRAY_LENGTH = 100_000;
 
 export interface DecodeOptions {
   typesKey?: string;
@@ -52,7 +53,7 @@ export function decode<T = unknown>(
   // Collect structural type paths and empty container paths
   const structuralPaths: [string, string][] = [];
   for (const [path, typeId] of Object.entries(types)) {
-    if (STRUCTURAL_TYPES.has(typeId)) {
+    if (isStructuralType(typeId)) {
       structuralPaths.push([path, typeId]);
     }
   }
@@ -61,7 +62,7 @@ export function decode<T = unknown>(
   const deserialized: [string, unknown][] = [];
   for (const [path, value] of raw) {
     const typeId = types[path];
-    if (typeId && !STRUCTURAL_TYPES.has(typeId)) {
+    if (typeId && !isStructuralType(typeId)) {
       const handler = getHandler(typeId, registry)!;
       try {
         deserialized.push([path, handler.deserialize(value)]);
@@ -85,12 +86,17 @@ export function decode<T = unknown>(
     if (entryPaths.has(path)) continue;
     if (parentPaths.has(path)) continue;
 
+    const sparseArrayLength = parseSparseArrayTypeId(typeId);
+
     if (typeId === "set") {
       deserialized.push([path, new Set()]);
     } else if (typeId === "map") {
       deserialized.push([path, new Map()]);
-    } else if (typeId === "array") {
-      deserialized.push([path, []]);
+    } else if (typeId === "array" || sparseArrayLength !== undefined) {
+      deserialized.push([
+        path,
+        sparseArrayLength === undefined ? [] : createSparseArray(sparseArrayLength),
+      ]);
     } else if (typeId === "object") {
       deserialized.push([path, {}]);
     }
@@ -98,6 +104,22 @@ export function decode<T = unknown>(
 
   // Unflatten into nested structure
   let result = unflatten(deserialized);
+
+  const sortedSparseArrays = structuralPaths
+    .map(([path, typeId]): [string, number] | undefined => {
+      const length = parseSparseArrayTypeId(typeId);
+      return length === undefined ? undefined : [path, length];
+    })
+    .filter((item): item is [string, number] => item !== undefined)
+    .sort((a, b) => b[0].length - a[0].length);
+
+  for (const [path, length] of sortedSparseArrays) {
+    if (path === "") {
+      if (Array.isArray(result)) result.length = length;
+    } else {
+      resizeArray(result, path, length);
+    }
+  }
 
   // Post-process structural types (deepest-first)
   const sortedStructural = structuralPaths
@@ -139,11 +161,33 @@ function validateTypesMetadata(
 
 function validateKnownTypeIds(types: Record<string, string>, registry: TypeRegistry): void {
   for (const [path, typeId] of Object.entries(types)) {
-    if (STRUCTURAL_TYPES.has(typeId)) continue;
+    if (isStructuralType(typeId)) continue;
     if (getHandler(typeId, registry)) continue;
 
     throw new TypeError(`Unknown type id "${typeId}" for typed field "${path}"`);
   }
+}
+
+function isStructuralType(typeId: string): boolean {
+  return STRUCTURAL_TYPES.has(typeId) || parseSparseArrayTypeId(typeId) !== undefined;
+}
+
+function parseSparseArrayTypeId(typeId: string): number | undefined {
+  if (!typeId.startsWith("array:")) return undefined;
+
+  const rawLength = typeId.slice("array:".length);
+  if (!/^(?:0|[1-9]\d*)$/.test(rawLength)) return undefined;
+
+  const length = Number(rawLength);
+  if (!Number.isSafeInteger(length) || length > MAX_ARRAY_LENGTH) return undefined;
+
+  return length;
+}
+
+function createSparseArray(length: number): unknown[] {
+  const array: unknown[] = [];
+  array.length = length;
+  return array;
 }
 
 function buildParentPathSet(paths: Set<string>): Set<string> {
@@ -228,4 +272,20 @@ function convertStructural(root: unknown, path: string, typeId: string): void {
   } else if (typeId === "map" && Array.isArray(value)) {
     current[lastSeg] = new Map(value as [unknown, unknown][]);
   }
+}
+
+function resizeArray(root: unknown, path: string, length: number): void {
+  const segments = parsePath(path);
+
+  if (segments.length === 0) return;
+
+  let current: Record<string | number, unknown> = root as Record<string | number, unknown>;
+  for (let i = 0; i < segments.length - 1; i++) {
+    current = current[segments[i]!] as Record<string | number, unknown>;
+    if (current === undefined) return;
+  }
+
+  const lastSeg = segments[segments.length - 1]!;
+  const value = current[lastSeg];
+  if (Array.isArray(value)) value.length = length;
 }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,4 +1,4 @@
-import { appendIndex, appendKey } from "./path.ts";
+import { MAX_SPARSE_ARRAY_LENGTH, appendIndex, appendKey } from "./path.ts";
 import { createTypeRegistry, findHandler, type TypeHandlerList } from "./types.ts";
 
 export const DEFAULT_TYPES_KEY = "$types";
@@ -238,6 +238,9 @@ function walk(
     }
     for (let i = 0; i < value.length; i++) {
       if (!(i in value)) {
+        if (value.length > MAX_SPARSE_ARRAY_LENGTH) {
+          throw new TypeError(`Sparse array length too large at path "${path}": ${value.length}`);
+        }
         types[path] = `array:${value.length}`;
         continue;
       }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -237,6 +237,10 @@ function walk(
       return;
     }
     for (let i = 0; i < value.length; i++) {
+      if (!(i in value)) {
+        types[path] = `array:${value.length}`;
+        continue;
+      }
       walk(value[i], appendIndex(path, i), entries, types, seen, registry);
     }
     seen.delete(value);

--- a/src/path.ts
+++ b/src/path.ts
@@ -16,6 +16,7 @@ export function appendIndex(path: string, index: number): string {
 }
 
 const MAX_ARRAY_INDEX = 100_000;
+export const MAX_SPARSE_ARRAY_LENGTH = 100_000;
 const ARRAY_INDEX_PATTERN = /^(?:0|[1-9]\d*)$/;
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -170,6 +170,30 @@ describe("encode/decode round-trip", () => {
     expect(roundtrip(input)).toEqual(input);
   });
 
+  test("top-level sparse array preserves holes", () => {
+    const input: unknown[] = [];
+    input[2] = "x";
+
+    const result = roundtrip(input) as unknown[];
+
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(1 in result).toBe(false);
+    expect(result[2]).toBe("x");
+  });
+
+  test("top-level sparse array preserves trailing holes", () => {
+    const input = ["x"] as unknown[];
+    input.length = 3;
+
+    const result = roundtrip(input) as unknown[];
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe("x");
+    expect(1 in result).toBe(false);
+    expect(2 in result).toBe(false);
+  });
+
   test("top-level Set", () => {
     const input = new Set(["a", "b", "c"]);
     const result = roundtrip(input);
@@ -234,6 +258,21 @@ describe("encode/decode round-trip", () => {
       ],
     };
     expect(roundtrip(input)).toEqual(input);
+  });
+
+  test("nested sparse arrays preserve holes", () => {
+    const input = {
+      items: [] as unknown[],
+    };
+    input.items[1] = "x";
+    input.items.length = 3;
+
+    const result = roundtrip(input) as { items: unknown[] };
+
+    expect(result.items).toHaveLength(3);
+    expect(0 in result.items).toBe(false);
+    expect(result.items[1]).toBe("x");
+    expect(2 in result.items).toBe(false);
   });
 
   test("array of mixed types", () => {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -194,6 +194,15 @@ describe("encode/decode round-trip", () => {
     expect(2 in result).toBe(false);
   });
 
+  test("oversized sparse array throws before emitting undecodable metadata", () => {
+    const input = ["x"] as unknown[];
+    input.length = 100_001;
+
+    expect(() => encode(input)).toThrow(
+      new TypeError('Sparse array length too large at path "": 100001'),
+    );
+  });
+
   test("top-level Set", () => {
     const input = new Set(["a", "b", "c"]);
     const result = roundtrip(input);


### PR DESCRIPTION
## Summary

Closes #28.

This PR preserves sparse array holes during `encode()` / `decode()` round trips instead of densifying absent elements into present `undefined` values.

## Root cause

The array encoder iterated from `0` to `value.length - 1` and read every index directly. For sparse arrays, reading a hole returns `undefined`, so the encoder serialized that hole as a real typed `undefined` entry. Decoding then reconstructed a dense array with present elements where the original had holes.

## Changes

- Skip absent array indexes during encoding so sparse holes are not emitted as leaf entries.
- Add sparse array length metadata using `array:<length>` for arrays that contain holes, which preserves trailing holes and all-hole sparse arrays.
- Apply sparse array length metadata during decode after unflattening.
- Add regression tests for top-level sparse arrays, top-level trailing holes, and nested sparse arrays.
- Add a patch changeset for the behavior fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
