### PR TITLE
[codex] Add URLSearchParams encode support

### DIFF
--- a/.changeset/large-crabs-search.md
+++ b/.changeset/large-crabs-search.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Add first-class `encode()` support for `URLSearchParams` inputs.

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -31,7 +31,12 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
 
   // FormData
   if (typeof FormData !== "undefined" && input instanceof FormData) {
-    return encodeFormData(input, typesKey, options?.types);
+    return encodeStringEntries(input, typesKey, options?.types);
+  }
+
+  // URLSearchParams
+  if (typeof URLSearchParams !== "undefined" && input instanceof URLSearchParams) {
+    return encodeStringEntries(input, typesKey, options?.types);
   }
 
   // Plain value (existing behavior)
@@ -149,8 +154,8 @@ function encodeForm(
   return entries;
 }
 
-function encodeFormData(
-  data: FormData,
+function encodeStringEntries(
+  data: Iterable<[string, string | File]>,
   typesKey: string,
   explicitTypes?: Record<string, string>,
 ): [string, string][] {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -248,6 +248,38 @@ describe("encode/decode round-trip", () => {
     expect(() => encode(new Date("not-a-date"))).toThrow(new TypeError('Invalid Date at path ""'));
   });
 
+  test("URLSearchParams encode as form-style entries", () => {
+    expect(encode(new URLSearchParams("name=Alice&count=42&tag=a&tag=b"))).toEqual([
+      ["name", "Alice"],
+      ["count", "42"],
+      ["tag", "a"],
+      ["tag", "b"],
+    ]);
+  });
+
+  test("URLSearchParams encode applies explicit types metadata", () => {
+    expect(
+      encode(new URLSearchParams("name=Alice&count=42"), {
+        types: { count: "number" },
+      }),
+    ).toEqual([
+      ["name", "Alice"],
+      ["count", "42"],
+      ["$types", JSON.stringify({ count: "number" })],
+    ]);
+  });
+
+  test("URLSearchParams encode merges existing and explicit types metadata", () => {
+    const params = new URLSearchParams("count=42&active=true");
+    params.set("$types", JSON.stringify({ count: "number" }));
+
+    expect(encode(params, { types: { active: "boolean" } })).toEqual([
+      ["count", "42"],
+      ["active", "true"],
+      ["$types", JSON.stringify({ count: "number", active: "boolean" })],
+    ]);
+  });
+
   test("nested invalid Date throws path-aware TypeError", () => {
     expect(() => encode({ post: { publishedAt: new Date("not-a-date") } })).toThrow(
       new TypeError('Invalid Date at path "post.publishedAt"'),

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -280,6 +280,16 @@ describe("encode/decode round-trip", () => {
     ]);
   });
 
+  test("URLSearchParams explicit types override existing metadata", () => {
+    const params = new URLSearchParams("count=42");
+    params.set("$types", JSON.stringify({ count: "number" }));
+
+    expect(encode(params, { types: { count: "bigint" } })).toEqual([
+      ["count", "42"],
+      ["$types", JSON.stringify({ count: "bigint" })],
+    ]);
+  });
+
   test("nested invalid Date throws path-aware TypeError", () => {
     expect(() => encode({ post: { publishedAt: new Date("not-a-date") } })).toThrow(
       new TypeError('Invalid Date at path "post.publishedAt"'),


### PR DESCRIPTION
## Summary

Adds first-class `encode()` support for `URLSearchParams` inputs, fixing #29.

`URLSearchParams` now uses the same string-entry path as `FormData`, so encoded URL query/body params preserve duplicate keys, ignore the metadata field as data, and merge existing `$types` metadata with explicit `types` options.

## Root Cause

`encode()` only had special handling for `HTMLFormElement` and `FormData`. `URLSearchParams` therefore fell through to rich JavaScript value serialization, where it was treated as an unsupported object and threw `TypeError: Unsupported type "URLSearchParams" at path ""`.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`

## Changeset

Included a patch changeset for `superformdata`.
