### PR TITLE
[codex] Preserve richer Error details

### DIFF
--- a/.changeset/gentle-errors-carry.md
+++ b/.changeset/gentle-errors-carry.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Preserve Error names and cause details when encoding and decoding Error values, while continuing to decode legacy plain-message Error payloads.

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface TypeRegistry {
 }
 
 interface SerializedError {
+  readonly __superformdataError: 1;
   readonly name: string;
   readonly message: string;
   readonly cause?: SerializedError | string;
@@ -87,6 +88,7 @@ function serializeErrorDetails(
     nextSeen.add(error);
 
     return {
+      __superformdataError: 1,
       name: error.name,
       message: error.message,
       cause: serializeErrorCause(cause, nextSeen),
@@ -94,6 +96,7 @@ function serializeErrorDetails(
   }
 
   return {
+    __superformdataError: 1,
     name: error.name,
     message: error.message,
   };
@@ -101,6 +104,7 @@ function serializeErrorDetails(
 
 function isSerializedError(value: unknown): value is SerializedError {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!("__superformdataError" in value) || value.__superformdataError !== 1) return false;
   if (!("name" in value) || typeof value.name !== "string") return false;
   if (!("message" in value) || typeof value.message !== "string") return false;
   if (!("cause" in value)) return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,18 @@ interface SerializedError {
   readonly __superformdataError: 1;
   readonly name: string;
   readonly message: string;
-  readonly cause?: SerializedError | string;
+  readonly cause?: SerializedError | SerializedErrorCause;
+}
+
+interface SerializedErrorCause {
+  readonly __superformdataErrorCause: 1;
+  readonly value: JsonValue;
+}
+
+type JsonValue = null | boolean | number | string | readonly JsonValue[] | JsonObject;
+
+interface JsonObject {
+  readonly [key: string]: JsonValue;
 }
 
 const NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
@@ -70,11 +81,34 @@ function deserializeBoolean(raw: string): boolean {
   return invalidTypedValue("boolean");
 }
 
-function serializeErrorCause(cause: unknown, seen: ReadonlySet<Error>): SerializedError | string {
+function serializeErrorCause(
+  cause: unknown,
+  seen: ReadonlySet<Error>,
+): SerializedError | SerializedErrorCause {
   if (cause instanceof Error) {
-    if (seen.has(cause)) return "[Circular Error cause]";
+    if (seen.has(cause)) {
+      return {
+        __superformdataErrorCause: 1,
+        value: "[Circular Error cause]",
+      };
+    }
     return serializeErrorDetails(cause, seen);
   }
+
+  return {
+    __superformdataErrorCause: 1,
+    value: toJsonErrorCause(cause),
+  };
+}
+
+function toJsonErrorCause(cause: unknown): JsonValue {
+  try {
+    const json = JSON.stringify(cause);
+    if (json !== undefined) return JSON.parse(json) as JsonValue;
+  } catch {
+    // Non-JSON causes still get a stable diagnostic representation.
+  }
+
   return String(cause);
 }
 
@@ -108,11 +142,19 @@ function isSerializedError(value: unknown): value is SerializedError {
   if (!("name" in value) || typeof value.name !== "string") return false;
   if (!("message" in value) || typeof value.message !== "string") return false;
   if (!("cause" in value)) return true;
-  return typeof value.cause === "string" || isSerializedError(value.cause);
+  return isSerializedError(value.cause) || isSerializedErrorCause(value.cause);
 }
 
-function deserializeErrorCause(cause: SerializedError | string): Error | string {
-  if (typeof cause === "string") return cause;
+function isSerializedErrorCause(value: unknown): value is SerializedErrorCause {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!("__superformdataErrorCause" in value) || value.__superformdataErrorCause !== 1) {
+    return false;
+  }
+  return "value" in value;
+}
+
+function deserializeErrorCause(cause: SerializedError | SerializedErrorCause): Error | JsonValue {
+  if (isSerializedErrorCause(cause)) return cause.value;
   return deserializeErrorDetails(cause);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,12 @@ export interface TypeRegistry {
   readonly handlerMap: ReadonlyMap<string, RegisteredTypeHandler>;
 }
 
+interface SerializedError {
+  readonly name: string;
+  readonly message: string;
+  readonly cause?: SerializedError | string;
+}
+
 const NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
 const RESERVED_TYPE_IDS = new Set(["set", "map", "array", "object"]);
 
@@ -61,6 +67,60 @@ function deserializeBoolean(raw: string): boolean {
   if (raw === "true") return true;
   if (raw === "false") return false;
   return invalidTypedValue("boolean");
+}
+
+function serializeErrorCause(cause: unknown): SerializedError | string {
+  if (cause instanceof Error) return serializeErrorDetails(cause);
+  return String(cause);
+}
+
+function serializeErrorDetails(error: Error): SerializedError {
+  if ("cause" in error) {
+    return {
+      name: error.name,
+      message: error.message,
+      cause: serializeErrorCause(error.cause),
+    };
+  }
+
+  return {
+    name: error.name,
+    message: error.message,
+  };
+}
+
+function isSerializedError(value: unknown): value is SerializedError {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  if (!("name" in value) || typeof value.name !== "string") return false;
+  if (!("message" in value) || typeof value.message !== "string") return false;
+  if (!("cause" in value)) return true;
+  return typeof value.cause === "string" || isSerializedError(value.cause);
+}
+
+function deserializeErrorCause(cause: SerializedError | string): Error | string {
+  if (typeof cause === "string") return cause;
+  return deserializeErrorDetails(cause);
+}
+
+function deserializeErrorDetails(details: SerializedError): Error {
+  const cause = details.cause;
+  const error =
+    cause === undefined
+      ? new Error(details.message)
+      : new Error(details.message, { cause: deserializeErrorCause(cause) });
+  error.name = details.name;
+  return error;
+}
+
+function deserializeError(raw: string): Error {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (isSerializedError(parsed)) return deserializeErrorDetails(parsed);
+  } catch {
+    // Legacy Error values were encoded as plain message strings.
+  }
+
+  return new Error(raw);
 }
 
 export const typeHandlers: RegisteredTypeHandler[] = [
@@ -121,8 +181,8 @@ export const typeHandlers: RegisteredTypeHandler[] = [
   defineTypeHandler({
     id: "Error",
     test: (v): v is Error => v instanceof Error,
-    serialize: (v) => v.message,
-    deserialize: (s) => new Error(s),
+    serialize: (v) => JSON.stringify(serializeErrorDetails(v)),
+    deserialize: deserializeError,
   }),
   defineTypeHandler({
     id: "number",

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,17 +69,27 @@ function deserializeBoolean(raw: string): boolean {
   return invalidTypedValue("boolean");
 }
 
-function serializeErrorCause(cause: unknown): SerializedError | string {
-  if (cause instanceof Error) return serializeErrorDetails(cause);
+function serializeErrorCause(cause: unknown, seen: ReadonlySet<Error>): SerializedError | string {
+  if (cause instanceof Error) {
+    if (seen.has(cause)) return "[Circular Error cause]";
+    return serializeErrorDetails(cause, seen);
+  }
   return String(cause);
 }
 
-function serializeErrorDetails(error: Error): SerializedError {
-  if ("cause" in error) {
+function serializeErrorDetails(
+  error: Error,
+  seen: ReadonlySet<Error> = new Set(),
+): SerializedError {
+  const cause = error.cause;
+  if (cause !== undefined) {
+    const nextSeen = new Set(seen);
+    nextSeen.add(error);
+
     return {
       name: error.name,
       message: error.message,
-      cause: serializeErrorCause(error.cause),
+      cause: serializeErrorCause(cause, nextSeen),
     };
   }
 

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -126,6 +126,23 @@ describe("encode/decode round-trip", () => {
     expect((result.err.cause as Error).message).toBe("root cause");
   });
 
+  test("Error with undefined cause does not create string cause", () => {
+    const result = roundtrip(new Error("missing cause", { cause: undefined })) as Error;
+
+    expect(result.message).toBe("missing cause");
+    expect(result.cause).toBeUndefined();
+  });
+
+  test("Error with circular cause serializes without stack overflow", () => {
+    const input = new Error("recursive");
+    input.cause = input;
+
+    const result = roundtrip(input) as Error;
+
+    expect(result.message).toBe("recursive");
+    expect(result.cause).toBe("[Circular Error cause]");
+  });
+
   test("special numbers", () => {
     const input = { a: NaN, b: Infinity, c: -Infinity, d: -0 };
     const result = roundtrip(input) as Record<string, number>;

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -143,6 +143,18 @@ describe("encode/decode round-trip", () => {
     expect(result.cause).toBe("[Circular Error cause]");
   });
 
+  test("Error preserves JSON-compatible non-Error cause values", () => {
+    const nullCause = roundtrip(new Error("null cause", { cause: null })) as Error;
+    const numberCause = roundtrip(new Error("number cause", { cause: 42 })) as Error;
+    const objectCause = roundtrip(
+      new Error("object cause", { cause: { code: "E_TEST", retryable: false } }),
+    ) as Error;
+
+    expect(nullCause.cause).toBeNull();
+    expect(numberCause.cause).toBe(42);
+    expect(objectCause.cause).toEqual({ code: "E_TEST", retryable: false });
+  });
+
   test("special numbers", () => {
     const input = { a: NaN, b: Infinity, c: -Infinity, d: -0 };
     const result = roundtrip(input) as Record<string, number>;

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -111,6 +111,21 @@ describe("encode/decode round-trip", () => {
     expect(result.err.message).toBe("something went wrong");
   });
 
+  test("Error preserves name and cause details", () => {
+    const input = {
+      err: new TypeError("bad input", { cause: new Error("root cause") }),
+    };
+
+    const result = roundtrip(input) as { err: Error };
+
+    expect(result.err).toBeInstanceOf(Error);
+    expect(result.err.name).toBe("TypeError");
+    expect(result.err.message).toBe("bad input");
+    expect(result.err.cause).toBeInstanceOf(Error);
+    expect((result.err.cause as Error).name).toBe("Error");
+    expect((result.err.cause as Error).message).toBe("root cause");
+  });
+
   test("special numbers", () => {
     const input = { a: NaN, b: Infinity, c: -Infinity, d: -0 };
     const result = roundtrip(input) as Record<string, number>;

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -78,7 +78,7 @@ describe("type registry", () => {
     ["Date", new Date("2024-01-01T00:00:00.000Z"), "2024-01-01T00:00:00.000Z"],
     ["RegExp", /foo/gi, "/foo/gi"],
     ["URL", new URL("https://example.com/path"), "https://example.com/path"],
-    ["Error", new Error("oops"), "oops"],
+    ["Error", new Error("oops"), JSON.stringify({ name: "Error", message: "oops" })],
     ["number", 42, "42"],
     ["number", 3.14, "3.14"],
     ["boolean", true, "true"],
@@ -128,6 +128,31 @@ describe("type registry", () => {
     } else {
       expect(result).toEqual(expected);
     }
+  });
+
+  test("Error deserializes structured details", () => {
+    const handler = getHandler("Error")!;
+    const result = handler.deserialize(
+      JSON.stringify({
+        name: "TypeError",
+        message: "bad input",
+        cause: { name: "Error", message: "root cause" },
+      }),
+    ) as Error;
+
+    expect(result.name).toBe("TypeError");
+    expect(result.message).toBe("bad input");
+    expect(result.cause).toBeInstanceOf(Error);
+    expect((result.cause as Error).name).toBe("Error");
+    expect((result.cause as Error).message).toBe("root cause");
+  });
+
+  test("Error deserializes legacy message strings", () => {
+    const handler = getHandler("Error")!;
+    const result = handler.deserialize("oops") as Error;
+
+    expect(result.name).toBe("Error");
+    expect(result.message).toBe("oops");
   });
 
   test("RegExp with special characters", () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -188,7 +188,39 @@ describe("type registry", () => {
         __superformdataError: 1,
         name: "Error",
         message: "recursive",
-        cause: "[Circular Error cause]",
+        cause: {
+          __superformdataErrorCause: 1,
+          value: "[Circular Error cause]",
+        },
+      }),
+    );
+  });
+
+  test("Error serializes non-Error causes without string coercion", () => {
+    const handler = getHandler("Error")!;
+
+    expect(handler.serialize(new Error("null cause", { cause: null }))).toBe(
+      JSON.stringify({
+        __superformdataError: 1,
+        name: "Error",
+        message: "null cause",
+        cause: { __superformdataErrorCause: 1, value: null },
+      }),
+    );
+    expect(handler.serialize(new Error("number cause", { cause: 42 }))).toBe(
+      JSON.stringify({
+        __superformdataError: 1,
+        name: "Error",
+        message: "number cause",
+        cause: { __superformdataErrorCause: 1, value: 42 },
+      }),
+    );
+    expect(handler.serialize(new Error("object cause", { cause: { code: "E_TEST" } }))).toBe(
+      JSON.stringify({
+        __superformdataError: 1,
+        name: "Error",
+        message: "object cause",
+        cause: { __superformdataErrorCause: 1, value: { code: "E_TEST" } },
       }),
     );
   });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -78,7 +78,11 @@ describe("type registry", () => {
     ["Date", new Date("2024-01-01T00:00:00.000Z"), "2024-01-01T00:00:00.000Z"],
     ["RegExp", /foo/gi, "/foo/gi"],
     ["URL", new URL("https://example.com/path"), "https://example.com/path"],
-    ["Error", new Error("oops"), JSON.stringify({ name: "Error", message: "oops" })],
+    [
+      "Error",
+      new Error("oops"),
+      JSON.stringify({ __superformdataError: 1, name: "Error", message: "oops" }),
+    ],
     ["number", 42, "42"],
     ["number", 3.14, "3.14"],
     ["boolean", true, "true"],
@@ -134,9 +138,10 @@ describe("type registry", () => {
     const handler = getHandler("Error")!;
     const result = handler.deserialize(
       JSON.stringify({
+        __superformdataError: 1,
         name: "TypeError",
         message: "bad input",
-        cause: { name: "Error", message: "root cause" },
+        cause: { __superformdataError: 1, name: "Error", message: "root cause" },
       }),
     ) as Error;
 
@@ -155,11 +160,22 @@ describe("type registry", () => {
     expect(result.message).toBe("oops");
   });
 
+  test("Error preserves legacy JSON-shaped message strings", () => {
+    const handler = getHandler("Error")!;
+    const legacyMessage = JSON.stringify({ name: "CustomError", message: "details" });
+    const result = handler.deserialize(legacyMessage) as Error;
+
+    expect(result.name).toBe("Error");
+    expect(result.message).toBe(legacyMessage);
+  });
+
   test("Error omits undefined cause while serializing", () => {
     const handler = getHandler("Error")!;
     const serialized = handler.serialize(new Error("oops", { cause: undefined }));
 
-    expect(serialized).toBe(JSON.stringify({ name: "Error", message: "oops" }));
+    expect(serialized).toBe(
+      JSON.stringify({ __superformdataError: 1, name: "Error", message: "oops" }),
+    );
   });
 
   test("Error serializes circular cause as a safe marker", () => {
@@ -169,6 +185,7 @@ describe("type registry", () => {
 
     expect(handler.serialize(error)).toBe(
       JSON.stringify({
+        __superformdataError: 1,
         name: "Error",
         message: "recursive",
         cause: "[Circular Error cause]",

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -155,6 +155,27 @@ describe("type registry", () => {
     expect(result.message).toBe("oops");
   });
 
+  test("Error omits undefined cause while serializing", () => {
+    const handler = getHandler("Error")!;
+    const serialized = handler.serialize(new Error("oops", { cause: undefined }));
+
+    expect(serialized).toBe(JSON.stringify({ name: "Error", message: "oops" }));
+  });
+
+  test("Error serializes circular cause as a safe marker", () => {
+    const handler = getHandler("Error")!;
+    const error = new Error("recursive");
+    error.cause = error;
+
+    expect(handler.serialize(error)).toBe(
+      JSON.stringify({
+        name: "Error",
+        message: "recursive",
+        cause: "[Circular Error cause]",
+      }),
+    );
+  });
+
   test("RegExp with special characters", () => {
     const handler = getHandler("RegExp")!;
     const regex = /^a\/b\d+$/i;


### PR DESCRIPTION
## Summary

Fixes #30 by preserving richer `Error` metadata during encode/decode round trips.

`Error` values now serialize as structured JSON containing `name`, `message`, and safe `cause` details. Decoding reconstructs an `Error` instance with the original name restored and nested `Error` causes reconstructed where possible.

## Root Cause

The built-in `Error` type handler serialized only `error.message` and deserialized with `new Error(message)`. That dropped diagnostic metadata such as `TypeError` names and `cause` chains, even though Errors are listed as supported rich values.

## Compatibility

The deserializer remains backward compatible with existing wire values that encoded Errors as plain message strings.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`

## Changeset

Included a patch changeset for `superformdata`.
