### PR TITLE
[codex] Reduce repeated handler scans and path parsing

### DIFF
--- a/.changeset/curly-ravens-parse.md
+++ b/.changeset/curly-ravens-parse.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reduce repeated handler scans and path parsing while encoding and decoding large payloads.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,5 +1,13 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
-import { MAX_SPARSE_ARRAY_LENGTH, appendIndex, appendKey, parsePath, unflatten } from "./path.ts";
+import {
+  MAX_SPARSE_ARRAY_LENGTH,
+  appendIndex,
+  appendKey,
+  parsePath,
+  unflattenParsed,
+  type ParsedPathEntry,
+  type PathSegment,
+} from "./path.ts";
 import {
   createTypeRegistry,
   getHandler,
@@ -8,6 +16,12 @@ import {
 } from "./types.ts";
 
 const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
+
+interface StructuralPath {
+  readonly path: string;
+  readonly segments: readonly PathSegment[];
+  readonly typeId: string;
+}
 
 export interface DecodeOptions {
   typesKey?: string;
@@ -50,82 +64,84 @@ export function decode<T = unknown>(
   }
 
   // Collect structural type paths and empty container paths
-  const structuralPaths: [string, string][] = [];
+  const structuralPaths: StructuralPath[] = [];
   for (const [path, typeId] of Object.entries(types)) {
     if (isStructuralType(typeId)) {
-      structuralPaths.push([path, typeId]);
+      structuralPaths.push({ path, segments: parsePath(path), typeId });
     }
   }
 
   // Deserialize leaf values
-  const deserialized: [string, unknown][] = [];
+  const deserialized: ParsedPathEntry[] = [];
   for (const [path, value] of raw) {
     const typeId = types[path];
+    const segments = parsePath(path);
     if (typeId && !isStructuralType(typeId)) {
       const handler = getHandler(typeId, registry)!;
       try {
-        deserialized.push([path, handler.deserialize(value)]);
+        deserialized.push({ path, segments, value: handler.deserialize(value) });
       } catch (error) {
         const reason = error instanceof Error ? error.message : `could not deserialize ${typeId}`;
         throw new TypeError(`Invalid value for typed field "${path}": ${reason}`);
       }
       continue;
     }
-    deserialized.push([path, value]);
+    deserialized.push({ path, segments, value });
   }
 
   // Build lookup sets once so empty-container reconstruction does not scan
   // all decoded entries for every structural metadata path.
   const entryPaths = new Set<string>();
-  for (const [p] of deserialized) entryPaths.add(p);
-  const parentPaths = buildParentPathSet(entryPaths);
+  for (const entry of deserialized) entryPaths.add(entry.path);
+  const parentPaths = buildParentPathSet(deserialized);
 
   // Add empty container markers
-  for (const [path, typeId] of structuralPaths) {
+  for (const { path, segments, typeId } of structuralPaths) {
     if (entryPaths.has(path)) continue;
     if (parentPaths.has(path)) continue;
 
     const sparseArrayLength = parseSparseArrayTypeId(typeId);
 
     if (typeId === "set") {
-      deserialized.push([path, new Set()]);
+      deserialized.push({ path, segments, value: new Set() });
     } else if (typeId === "map") {
-      deserialized.push([path, new Map()]);
+      deserialized.push({ path, segments, value: new Map() });
     } else if (typeId === "array" || sparseArrayLength !== undefined) {
-      deserialized.push([
+      deserialized.push({
         path,
-        sparseArrayLength === undefined ? [] : createSparseArray(sparseArrayLength),
-      ]);
+        segments,
+        value: sparseArrayLength === undefined ? [] : createSparseArray(sparseArrayLength),
+      });
     } else if (typeId === "object") {
-      deserialized.push([path, {}]);
+      deserialized.push({ path, segments, value: {} });
     }
   }
 
   // Unflatten into nested structure
-  let result = unflatten(deserialized);
+  let result = unflattenParsed(deserialized);
 
   const sortedSparseArrays = structuralPaths
-    .map(([path, typeId]): [string, number] | undefined => {
+    .map(({ path, segments, typeId }): [string, readonly PathSegment[], number] | undefined => {
       const length = parseSparseArrayTypeId(typeId);
-      return length === undefined ? undefined : [path, length];
+      return length === undefined ? undefined : [path, segments, length];
     })
-    .filter((item): item is [string, number] => item !== undefined)
+    .filter((item): item is [string, readonly PathSegment[], number] => item !== undefined)
     .sort((a, b) => b[0].length - a[0].length);
 
-  for (const [path, length] of sortedSparseArrays) {
+  for (const [path, segments, length] of sortedSparseArrays) {
     if (path === "") {
       if (Array.isArray(result)) result.length = length;
     } else {
-      resizeArray(result, path, length);
+      resizeArray(result, segments, length);
     }
   }
 
   // Post-process structural types (deepest-first)
   const sortedStructural = structuralPaths
-    .filter(([, t]) => t === "set" || t === "map")
-    .sort((a, b) => b[0].length - a[0].length);
+    .filter(({ typeId }) => typeId === "set" || typeId === "map")
+    .sort((a, b) => b.path.length - a.path.length);
 
-  for (const [path, typeId] of sortedStructural) {
+  for (const { path, segments, typeId } of sortedStructural) {
     if (path === "") {
       // Top-level structural type
       if (typeId === "set" && Array.isArray(result)) {
@@ -134,7 +150,7 @@ export function decode<T = unknown>(
         result = new Map(result as [unknown, unknown][]);
       }
     } else {
-      convertStructural(result, path, typeId);
+      convertStructural(result, segments, typeId);
     }
   }
 
@@ -189,11 +205,10 @@ function createSparseArray(length: number): unknown[] {
   return array;
 }
 
-function buildParentPathSet(paths: Set<string>): Set<string> {
+function buildParentPathSet(entries: readonly ParsedPathEntry[]): Set<string> {
   const parentPaths = new Set<string>();
 
-  for (const path of paths) {
-    const segments = parsePath(path);
+  for (const { segments } of entries) {
     if (segments.length === 0) continue;
 
     parentPaths.add("");
@@ -243,9 +258,7 @@ export async function decodeRequest<T = unknown>(
   );
 }
 
-function convertStructural(root: unknown, path: string, typeId: string): void {
-  const segments = parsePath(path);
-
+function convertStructural(root: unknown, segments: readonly PathSegment[], typeId: string): void {
   if (segments.length === 0) {
     // Can't convert root in-place; this shouldn't happen for structural types
     // at root level since unflatten returns the array/object directly
@@ -273,9 +286,7 @@ function convertStructural(root: unknown, path: string, typeId: string): void {
   }
 }
 
-function resizeArray(root: unknown, path: string, length: number): void {
-  const segments = parsePath(path);
-
+function resizeArray(root: unknown, segments: readonly PathSegment[], length: number): void {
   if (segments.length === 0) return;
 
   let current: Record<string | number, unknown> = root as Record<string | number, unknown>;

--- a/src/path.ts
+++ b/src/path.ts
@@ -23,6 +23,12 @@ const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 export type PathSegment = string | number;
 type PathContainer = Record<string | number, unknown>;
 
+export interface ParsedPathEntry {
+  readonly path: string;
+  readonly segments: readonly PathSegment[];
+  readonly value: unknown;
+}
+
 function assertSafePathSegment(segment: PathSegment, path: string): void {
   if (typeof segment === "number") return;
   if (!UNSAFE_OBJECT_KEYS.has(segment)) return;
@@ -147,16 +153,15 @@ export function parsePath(path: string): PathSegment[] {
   return segments;
 }
 
-export function unflatten(entries: [string, unknown][]): unknown {
+export function unflattenParsed(entries: readonly ParsedPathEntry[]): unknown {
   if (entries.length === 0) return {};
-  if (entries.length === 1 && entries[0]![0] === "") return entries[0]![1];
+  if (entries.length === 1 && entries[0]!.path === "") return entries[0]!.value;
 
-  const firstPath = entries[0]![0];
+  const firstPath = entries[0]!.path;
   const root = (firstPath.startsWith("[") ? [] : {}) as PathContainer;
   const containers = new WeakSet<object>([root]);
 
-  for (const [path, value] of entries) {
-    const segments = parsePath(path);
+  for (const { path, segments, value } of entries) {
     if (segments.length === 0) continue;
     for (const segment of segments) {
       assertSafePathSegment(segment, path);
@@ -190,4 +195,14 @@ export function unflatten(entries: [string, unknown][]): unknown {
   }
 
   return root;
+}
+
+export function unflatten(entries: [string, unknown][]): unknown {
+  return unflattenParsed(
+    entries.map(([path, value]) => ({
+      path,
+      segments: parsePath(path),
+      value,
+    })),
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ type RegisteredTypeHandler = TypeHandler<unknown>;
 export interface TypeRegistry {
   readonly handlers: readonly RegisteredTypeHandler[];
   readonly handlerMap: ReadonlyMap<string, RegisteredTypeHandler>;
+  readonly customHandlers: readonly RegisteredTypeHandler[];
 }
 
 interface SerializedError {
@@ -269,6 +270,7 @@ for (const handler of typeHandlers) {
 const builtInRegistry: TypeRegistry = {
   handlers: typeHandlers,
   handlerMap,
+  customHandlers: [],
 };
 
 export function createTypeRegistry(customHandlers?: TypeHandlerList): TypeRegistry {
@@ -297,7 +299,34 @@ export function createTypeRegistry(customHandlers?: TypeHandlerList): TypeRegist
   return {
     handlers: [...handlers, ...typeHandlers],
     handlerMap: customHandlerMap,
+    customHandlers: handlers,
   };
+}
+
+function findBuiltInHandler(value: unknown): RegisteredTypeHandler | undefined {
+  if (value === undefined) return handlerMap.get("undefined");
+  if (value === null) return handlerMap.get("null");
+
+  switch (typeof value) {
+    case "bigint":
+      return handlerMap.get("bigint");
+    case "boolean":
+      return handlerMap.get("boolean");
+    case "number":
+      if (Number.isNaN(value)) return handlerMap.get("nan");
+      if (value === Infinity) return handlerMap.get("infinity");
+      if (value === -Infinity) return handlerMap.get("-infinity");
+      if (Object.is(value, -0)) return handlerMap.get("-0");
+      return handlerMap.get("number");
+    case "string":
+      return undefined;
+    default:
+      if (value instanceof Date) return handlerMap.get("Date");
+      if (value instanceof RegExp) return handlerMap.get("RegExp");
+      if (value instanceof URL) return handlerMap.get("URL");
+      if (value instanceof Error) return handlerMap.get("Error");
+      return undefined;
+  }
 }
 
 export function findHandler(
@@ -305,7 +334,8 @@ export function findHandler(
   registry: TypeRegistry = builtInRegistry,
 ): RegisteredTypeHandler | undefined {
   if (typeof value === "string") return undefined;
-  return registry.handlers.find((h) => h.test(value));
+  if (registry.customHandlers.length > 0) return registry.handlers.find((h) => h.test(value));
+  return findBuiltInHandler(value);
 }
 
 export function getHandler(

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,7 @@ export function createTypeRegistry(customHandlers?: TypeHandlerList): TypeRegist
 }
 
 function findBuiltInHandler(value: unknown): RegisteredTypeHandler | undefined {
+  // Keep this fast-path in sync with typeHandlers; tests compare it against the canonical scan.
   if (value === undefined) return handlerMap.get("undefined");
   if (value === null) return handlerMap.get("null");
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { decode, decodeRequest, encode, type TypeHandler } from "../src/index.ts";
-import { findHandler, getHandler } from "../src/types.ts";
+import { findHandler, getHandler, typeHandlers } from "../src/types.ts";
 
 type Assert<T extends true> = T;
 type Equal<A, B> =
@@ -66,6 +66,33 @@ const moneyHandler: TypeHandler<Money> = {
 describe("type registry", () => {
   test("findHandler returns undefined for strings", () => {
     expect(findHandler("hello")).toBeUndefined();
+  });
+
+  test("built-in handler fast path stays in sync with the canonical handler scan", () => {
+    const values = [
+      undefined,
+      NaN,
+      Infinity,
+      -Infinity,
+      -0,
+      42n,
+      new Date("2024-01-01T00:00:00.000Z"),
+      /foo/gi,
+      new URL("https://example.com/path"),
+      new Error("oops"),
+      42,
+      3.14,
+      true,
+      false,
+      null,
+      "hello",
+      {},
+      [],
+    ];
+
+    for (const value of values) {
+      expect(findHandler(value)?.id).toBe(typeHandlers.find((handler) => handler.test(value))?.id);
+    }
   });
 
   test.each([

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -308,6 +308,21 @@ describe("type registry", () => {
     ]);
   });
 
+  test("custom type handlers keep priority over built-in primitive handlers", () => {
+    const integerHandler: TypeHandler<number> = {
+      id: "Integer",
+      test: (value): value is number => Number.isInteger(value),
+      serialize: (value) => String(value),
+      deserialize: (raw) => Number(raw),
+    };
+
+    expect(encode({ count: 42, ratio: 3.14 }, { typeHandlers: [integerHandler] })).toEqual([
+      ["count", "42"],
+      ["ratio", "3.14"],
+      ["$types", JSON.stringify({ count: "Integer", ratio: "number" })],
+    ]);
+  });
+
   test("custom type handlers decode explicitly typed entries", () => {
     expect(
       decode<{ price: Money }>(


### PR DESCRIPTION
## Summary

Closes #31.

This PR reduces avoidable repeated work in the encode/decode hot paths without changing the public API or supported payload behavior.

## Changes

- Adds direct built-in handler resolution for the default registry so encoding rich leaf values no longer scans the built-in handler list for every non-string leaf.
- Preserves custom handler priority when custom handlers are provided, including custom handlers that intentionally match primitive values.
- Parses decode paths once for raw entries and structural metadata, then reuses those parsed segments for parent-path collection, unflattening, sparse-array resizing, and set/map conversion.
- Adds regression coverage confirming custom primitive handler priority is preserved.
- Adds a patch changeset for the performance improvement.

## Impact

Large nested payloads should do less repeated parsing during decode, and default encode paths avoid repeated built-in handler scans. The observable serialization format and decode behavior remain unchanged.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`
- `bun run build`
