### PR TITLE
[codex] Preserve empty string object keys

### DIFF
--- a/.changeset/empty-keys-roundtrip.md
+++ b/.changeset/empty-keys-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Preserve empty string object keys during encode/decode round trips.

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,8 +1,10 @@
 export function escapeKey(key: string): string {
+  if (key === "") return "\\0";
   return key.replace(/[.[\]\\]/g, "\\$&");
 }
 
 export function unescapeKey(escaped: string): string {
+  if (escaped === "\\0") return "";
   return escaped.replace(/\\(.)/g, "$1");
 }
 
@@ -112,31 +114,37 @@ export function parsePath(path: string): PathSegment[] {
 
   const segments: PathSegment[] = [];
   let current = "";
+  let hasCurrentSegment = false;
   let i = 0;
 
   while (i < path.length) {
     if (path[i] === "\\") {
       if (i + 1 < path.length) {
-        current += path[i + 1];
+        current += path[i + 1] === "0" ? "" : path[i + 1];
+        hasCurrentSegment = true;
         i += 2;
       } else {
         // Trailing backslash — treat as literal
         current += "\\";
+        hasCurrentSegment = true;
         i++;
       }
     } else if (path[i] === ".") {
       segments.push(current);
       current = "";
+      hasCurrentSegment = false;
       i++;
     } else if (path[i] === "[") {
       if (current !== "" || (segments.length === 0 && i > 0)) {
         segments.push(current);
         current = "";
+        hasCurrentSegment = false;
       }
       const close = path.indexOf("]", i);
       if (close === -1) {
         // Malformed bracket — treat rest as literal
         current += path.slice(i);
+        hasCurrentSegment = true;
         break;
       }
       segments.push(parseArrayIndex(path.slice(i + 1, close), path));
@@ -145,11 +153,12 @@ export function parsePath(path: string): PathSegment[] {
       if (path[i] === ".") i++;
     } else {
       current += path[i];
+      hasCurrentSegment = true;
       i++;
     }
   }
 
-  if (current !== "" || segments.length === 0) segments.push(current);
+  if (hasCurrentSegment || segments.length === 0) segments.push(current);
   return segments;
 }
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -135,7 +135,7 @@ export function parsePath(path: string): PathSegment[] {
       hasCurrentSegment = false;
       i++;
     } else if (path[i] === "[") {
-      if (current !== "" || (segments.length === 0 && i > 0)) {
+      if (current !== "" || hasCurrentSegment || (segments.length === 0 && i > 0)) {
         segments.push(current);
         current = "";
         hasCurrentSegment = false;

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -27,7 +27,7 @@ describe("escapeKey / unescapeKey", () => {
   });
 
   test("round-trip", () => {
-    const keys = ["simple", "a.b.c", "x[0]", "a\\b", "complex.key[1]\\end"];
+    const keys = ["", "simple", "a.b.c", "x[0]", "a\\b", "complex.key[1]\\end"];
     for (const key of keys) {
       expect(unescapeKey(escapeKey(key))).toBe(key);
     }
@@ -129,6 +129,11 @@ describe("parsePath", () => {
   test("escaped empty string key", () => {
     expect(parsePath("\\0")).toEqual([""]);
     expect(parsePath("user.\\0")).toEqual(["user", ""]);
+  });
+
+  test("escaped empty string key before array index", () => {
+    expect(parsePath("\\0[0]")).toEqual(["", 0]);
+    expect(parsePath("parent.\\0[0]")).toEqual(["parent", "", 0]);
   });
 
   test("leading dot (.name)", () => {

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -39,6 +39,11 @@ describe("appendKey / appendIndex", () => {
     expect(appendKey("", "name")).toBe("name");
   });
 
+  test("appendKey preserves empty string key", () => {
+    expect(appendKey("", "")).toBe("\\0");
+    expect(appendKey("user", "")).toBe("user.\\0");
+  });
+
   test("appendKey to existing path", () => {
     expect(appendKey("user", "name")).toBe("user.name");
   });
@@ -119,6 +124,11 @@ describe("parsePath", () => {
 
   test("empty string key (a..b)", () => {
     expect(parsePath("a..b")).toEqual(["a", "", "b"]);
+  });
+
+  test("escaped empty string key", () => {
+    expect(parsePath("\\0")).toEqual([""]);
+    expect(parsePath("user.\\0")).toEqual(["user", ""]);
   });
 
   test("leading dot (.name)", () => {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -198,6 +198,11 @@ describe("encode/decode round-trip", () => {
     expect(roundtrip(input)).toEqual(input);
   });
 
+  test("empty string object key with array value", () => {
+    const input = { "": [1, 2], parent: { "": [3, 4] } };
+    expect(roundtrip(input)).toEqual(input);
+  });
+
   test("deeply nested mixed types", () => {
     const input = {
       users: [

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -183,6 +183,21 @@ describe("encode/decode round-trip", () => {
     expect(roundtrip(input)).toEqual(input);
   });
 
+  test("top-level empty string object key", () => {
+    const input = { "": "x" };
+    expect(roundtrip(input)).toEqual(input);
+  });
+
+  test("nested empty string object key", () => {
+    const input = { user: { "": "x" } };
+    expect(roundtrip(input)).toEqual(input);
+  });
+
+  test("mixed empty string object keys with siblings", () => {
+    const input = { "": "root", user: { "": "nested", name: "Alice" }, value: "sibling" };
+    expect(roundtrip(input)).toEqual(input);
+  });
+
   test("deeply nested mixed types", () => {
     const input = {
       users: [


### PR DESCRIPTION
## Summary

Fixes #43.

This preserves empty string object keys during encode/decode round trips by encoding them as an explicit escaped path segment (`\\0`) instead of allowing them to collapse into the root path. The parser now tracks whether the current segment was explicitly present, so nested empty-key paths such as `user.\\0` decode to `['user', '']` rather than dropping the trailing segment.

## Impact

Objects like `{ "": "x" }`, nested empty-key objects, and mixed sibling shapes now round-trip without silently changing shape.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
