### PR TITLE
[codex] Exclude non-successful form elements

### DIFF
--- a/.changeset/clean-forms-submit.md
+++ b/.changeset/clean-forms-submit.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Exclude listed form elements that are not successful controls when encoding forms.

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -63,6 +63,17 @@ function isSubmitButton(el: Element): boolean {
   return false;
 }
 
+function isSubmittableFormControl(
+  element: Element,
+): element is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | HTMLButtonElement {
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLSelectElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLButtonElement
+  );
+}
+
 function isInsideFirstLegend(element: Element, fieldset: HTMLFieldSetElement): boolean {
   const firstLegend = fieldset.querySelector(":scope > legend");
   return firstLegend?.contains(element) ?? false;
@@ -88,7 +99,9 @@ function encodeForm(
   const types: Record<string, string> = { ...explicitTypes };
 
   for (const element of form.elements) {
-    const el = element as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+    if (!isSubmittableFormControl(element)) continue;
+    const el = element;
+
     if (!el.name || el.disabled || isDisabledByFieldset(el)) continue;
     if (el.name === typesKey) continue;
 
@@ -105,6 +118,10 @@ function encodeForm(
       if (el === submitter) {
         entries.push([el.name, el.value]);
       }
+      continue;
+    }
+
+    if (el instanceof HTMLInputElement && (el.type === "button" || el.type === "reset")) {
       continue;
     }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -264,6 +264,20 @@ describe("encode(form)", () => {
     expect(entries).toEqual([["name", "Alice"]]);
   });
 
+  test("skips listed elements that are not successful controls", () => {
+    const form = createForm(
+      '<fieldset name="group"><input name="x" value="1" /></fieldset>' +
+        '<output name="result">42</output>' +
+        '<object name="plugin"></object>' +
+        '<input name="noop" type="button" value="ignored" />' +
+        '<input name="reset" type="reset" value="ignored" />',
+    );
+    const entries = encode(form);
+
+    expect(entries).toEqual([["x", "1"]]);
+    expect(entries.every(([, value]) => typeof value === "string")).toBe(true);
+  });
+
   test("skips controls in disabled fieldsets except controls in the first legend", () => {
     const form = createForm(
       "<fieldset disabled>" +

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -272,6 +272,16 @@ describe("encode(form)", () => {
         '<input name="noop" type="button" value="ignored" />' +
         '<input name="reset" type="reset" value="ignored" />',
     );
+
+    expect(Array.from(form.elements, (element) => element.tagName)).toEqual([
+      "FIELDSET",
+      "INPUT",
+      "OUTPUT",
+      "OBJECT",
+      "INPUT",
+      "INPUT",
+    ]);
+
     const entries = encode(form);
 
     expect(entries).toEqual([["x", "1"]]);


### PR DESCRIPTION
## Summary

Fixes #44 by making `encode(form)` skip listed form elements that are not successful controls before reading `.value`. This prevents elements like `<fieldset>`, `<output>`, and `<object>` from producing entries, and keeps `input[type=button]` / `input[type=reset]` out of encoded output as browser form submission would.

## Root Cause

`encodeForm()` iterated `form.elements`, broadly cast each listed element to an input/select/textarea-like control, then pushed `input.value` in the fallback branch. Listed-but-non-successful elements can appear in `form.elements`, so the encoder could emit names that a native form submission would omit and could also produce non-string values.

## Changes

- Added a submittable-control guard for form encoding.
- Excluded `input[type=button]` and `input[type=reset]` from encoded form entries.
- Added a regression test covering `fieldset`, `output`, `object`, button inputs, and reset inputs.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `git diff --check`
