### PR TITLE
[codex] Reject mixed root decode paths

### DIFF
--- a/.changeset/reject-mixed-root-paths.md
+++ b/.changeset/reject-mixed-root-paths.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject mixed top-level object and array paths during `decode()` instead of producing hybrid root containers.

--- a/src/path.ts
+++ b/src/path.ts
@@ -93,6 +93,14 @@ function assertCompatibleContainer(
   }
 }
 
+function assertCompatibleRoot(root: PathContainer, firstSegment: PathSegment, path: string): void {
+  if (Array.isArray(root) === (typeof firstSegment === "number")) return;
+
+  throw new TypeError(
+    `Path collision at root while decoding path "${path}": incompatible container type`,
+  );
+}
+
 function parseArrayIndex(raw: string, path: string): number {
   if (!ARRAY_INDEX_PATTERN.test(raw)) {
     throw new TypeError(`Invalid array index "${raw}" in path "${path}"`);
@@ -177,6 +185,7 @@ export function unflattenParsed(entries: readonly ParsedPathEntry[]): unknown {
     }
 
     let current: PathContainer = root;
+    assertCompatibleRoot(root, segments[0]!, path);
 
     for (let i = 0; i < segments.length - 1; i++) {
       const seg = segments[i]!;

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -259,6 +259,24 @@ describe("unflatten", () => {
     ).toThrow('Path collision at "a" while decoding path "a[0]": incompatible container type');
   });
 
+  test("rejects object root before array root path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["a", "x"],
+        ["[0]", "y"],
+      ]),
+    ).toThrow('Path collision at root while decoding path "[0]": incompatible container type');
+  });
+
+  test("rejects array root before object root path collisions", () => {
+    expect(() =>
+      unflatten([
+        ["[0]", "y"],
+        ["a", "x"],
+      ]),
+    ).toThrow('Path collision at root while decoding path "a": incompatible container type');
+  });
+
   test("rejects path segments that can mutate object prototypes", () => {
     expect(() => unflatten([["__proto__.polluted", "yes"]])).toThrow(
       'Unsafe path segment "__proto__"',


### PR DESCRIPTION
## Summary

Fixes #45 by rejecting mixed top-level object-style and array-style paths during decode/unflattening.

## Root cause

`unflattenParsed()` selected the root container type from the first path only. Later paths with a different root segment kind were assigned into that same root, which allowed object roots to gain numeric keys or array roots to gain custom object properties.

## Changes

- Added root container compatibility validation for each decoded path before assignment.
- Added regression coverage for both ordering cases: object path first then array path, and array path first then object path.
- Added a patch changeset documenting the decode behavior fix.

## Validation

- `bun test test/path.test.ts` failed before the fix for both new regression cases.
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
