### PR TITLE
[codex] Reject mismatched structural metadata

### DIFF
--- a/.changeset/strict-structural-metadata.md
+++ b/.changeset/strict-structural-metadata.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject decoded values when `set` or `map` structural metadata does not match the decoded value shape.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -281,7 +281,7 @@ function convertStructural(
   let current: Record<string | number, unknown> = root as Record<string | number, unknown>;
   for (let i = 0; i < segments.length - 1; i++) {
     current = current[segments[i]!] as Record<string | number, unknown>;
-    if (current === undefined) throwStructuralMismatch(path, typeId);
+    if (current === null || current === undefined) throwStructuralMismatch(path, typeId);
   }
 
   const lastSeg = segments[segments.length - 1]!;

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -148,9 +148,11 @@ export function decode<T = unknown>(
         result = new Set(result);
       } else if (typeId === "map" && Array.isArray(result)) {
         result = new Map(result as [unknown, unknown][]);
+      } else if (!isConvertedStructuralValue(result, typeId)) {
+        throwStructuralMismatch(path, typeId);
       }
     } else {
-      convertStructural(result, segments, typeId);
+      convertStructural(result, path, segments, typeId);
     }
   }
 
@@ -258,7 +260,18 @@ export async function decodeRequest<T = unknown>(
   );
 }
 
-function convertStructural(root: unknown, segments: readonly PathSegment[], typeId: string): void {
+function throwStructuralMismatch(path: string, typeId: string): never {
+  throw new TypeError(
+    `Invalid superformdata metadata: structural type "${typeId}" at path "${path}" does not match decoded value shape`,
+  );
+}
+
+function convertStructural(
+  root: unknown,
+  path: string,
+  segments: readonly PathSegment[],
+  typeId: string,
+): void {
   if (segments.length === 0) {
     // Can't convert root in-place; this shouldn't happen for structural types
     // at root level since unflatten returns the array/object directly
@@ -268,13 +281,13 @@ function convertStructural(root: unknown, segments: readonly PathSegment[], type
   let current: Record<string | number, unknown> = root as Record<string | number, unknown>;
   for (let i = 0; i < segments.length - 1; i++) {
     current = current[segments[i]!] as Record<string | number, unknown>;
-    if (current === undefined) return;
+    if (current === undefined) throwStructuralMismatch(path, typeId);
   }
 
   const lastSeg = segments[segments.length - 1]!;
   const value = current[lastSeg];
 
-  if (value instanceof Set || value instanceof Map) {
+  if (isConvertedStructuralValue(value, typeId)) {
     // Already converted (empty container case)
     return;
   }
@@ -283,7 +296,13 @@ function convertStructural(root: unknown, segments: readonly PathSegment[], type
     current[lastSeg] = new Set(value);
   } else if (typeId === "map" && Array.isArray(value)) {
     current[lastSeg] = new Map(value as [unknown, unknown][]);
+  } else {
+    throwStructuralMismatch(path, typeId);
   }
+}
+
+function isConvertedStructuralValue(value: unknown, typeId: string): boolean {
+  return (typeId === "set" && value instanceof Set) || (typeId === "map" && value instanceof Map);
 }
 
 function resizeArray(root: unknown, segments: readonly PathSegment[], length: number): void {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -616,6 +616,38 @@ describe("encode/decode round-trip", () => {
     });
   });
 
+  test("decode rejects nested structural metadata when the decoded shape is incompatible", () => {
+    expect(() =>
+      decode([
+        ["items.name", "x"],
+        ["$types", JSON.stringify({ items: "set" })],
+      ]),
+    ).toThrow('Invalid superformdata metadata: structural type "set" at path "items"');
+
+    expect(() =>
+      decode([
+        ["lookup.name", "x"],
+        ["$types", JSON.stringify({ lookup: "map" })],
+      ]),
+    ).toThrow('Invalid superformdata metadata: structural type "map" at path "lookup"');
+  });
+
+  test("decode rejects root structural metadata when the decoded shape is incompatible", () => {
+    expect(() =>
+      decode([
+        ["items.name", "x"],
+        ["$types", JSON.stringify({ "": "set" })],
+      ]),
+    ).toThrow('Invalid superformdata metadata: structural type "set" at path ""');
+
+    expect(() =>
+      decode([
+        ["items.name", "x"],
+        ["$types", JSON.stringify({ "": "map" })],
+      ]),
+    ).toThrow('Invalid superformdata metadata: structural type "map" at path ""');
+  });
+
   test("custom typesKey", () => {
     const input = { count: 42, $types: "user data here" };
     const entries = encode(input, { typesKey: "__meta" });


### PR DESCRIPTION
## Summary

Fixes #46 by rejecting malformed structural `$types` metadata when it promises a `set` or `map` but the decoded value is not array-shaped and cannot be converted into that structure.

## Root Cause

`decode()` collected structural metadata and converted `set`/`map` paths only when the decoded value was an array. If the entries produced an object shape instead, the conversion branch silently did nothing and returned data that contradicted the metadata. The same behavior existed for root-level `set` and `map` metadata.

## Changes

- Added explicit `TypeError` failures for nested and root-level `set`/`map` metadata shape mismatches.
- Preserved successful conversion for array-shaped values and already-created empty `Set`/`Map` containers.
- Added regression tests for nested and top-level `set` and `map` mismatch cases.
- Added a patch changeset for the bug fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun test`
- `bun typecheck`
