### PR TITLE
fix: validate encode type metadata

### DIFF
--- a/.changeset/validate-encode-type-metadata.md
+++ b/.changeset/validate-encode-type-metadata.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Validate type metadata generated or forwarded by `encode()` and client change helpers.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,10 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
 import { validateKnownTypeId } from "./metadata.ts";
-import { createTypeRegistry } from "./types.ts";
+import { createTypeRegistry, type TypeHandlerList } from "./types.ts";
 
 export interface ChangeHandlerOptions {
   readonly typesKey?: string;
+  readonly typeHandlers?: TypeHandlerList;
 }
 
 export interface ChangeHandlers {
@@ -63,7 +64,7 @@ function createBooleanChangeHandler(typesKey: string): (event: Event) => void {
 
 export function onChange(typeId: string, options?: ChangeHandlerOptions): (event: Event) => void {
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
-  const registry = createTypeRegistry();
+  const registry = createTypeRegistry(options?.typeHandlers);
 
   return (event: Event) => {
     const input = event.target as HTMLInputElement;
@@ -79,11 +80,11 @@ export function createChangeHandlers(options?: ChangeHandlerOptions): ChangeHand
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
 
   return {
-    onDateChange: onChange("Date", { typesKey }),
-    onNumberChange: onChange("number", { typesKey }),
+    onDateChange: onChange("Date", options),
+    onNumberChange: onChange("number", options),
     onBooleanChange: createBooleanChangeHandler(typesKey),
-    onBigIntChange: onChange("bigint", { typesKey }),
-    onURLChange: onChange("URL", { typesKey }),
+    onBigIntChange: onChange("bigint", options),
+    onURLChange: onChange("URL", options),
   };
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,6 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
+import { validateKnownTypeId } from "./metadata.ts";
+import { createTypeRegistry } from "./types.ts";
 
 export interface ChangeHandlerOptions {
   readonly typesKey?: string;
@@ -61,11 +63,13 @@ function createBooleanChangeHandler(typesKey: string): (event: Event) => void {
 
 export function onChange(typeId: string, options?: ChangeHandlerOptions): (event: Event) => void {
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
+  const registry = createTypeRegistry();
 
   return (event: Event) => {
     const input = event.target as HTMLInputElement;
     if (!input.name || !input.form) return;
 
+    validateKnownTypeId(input.name, typeId, registry);
     input.dataset.sfType = typeId;
     updateFormTypes(input.form, input.name, typeId, typesKey);
   };

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
+import { isStructuralType, parseSparseArrayTypeId, validateKnownTypeIds } from "./metadata.ts";
 import {
-  MAX_SPARSE_ARRAY_LENGTH,
   appendIndex,
   appendKey,
   parsePath,
@@ -8,14 +8,7 @@ import {
   type ParsedPathEntry,
   type PathSegment,
 } from "./path.ts";
-import {
-  createTypeRegistry,
-  getHandler,
-  type TypeHandlerList,
-  type TypeRegistry,
-} from "./types.ts";
-
-const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
+import { createTypeRegistry, getHandler, type TypeHandlerList } from "./types.ts";
 
 interface StructuralPath {
   readonly path: string;
@@ -174,31 +167,6 @@ function validateTypesMetadata(
       );
     }
   }
-}
-
-function validateKnownTypeIds(types: Record<string, string>, registry: TypeRegistry): void {
-  for (const [path, typeId] of Object.entries(types)) {
-    if (isStructuralType(typeId)) continue;
-    if (getHandler(typeId, registry)) continue;
-
-    throw new TypeError(`Unknown type id "${typeId}" for typed field "${path}"`);
-  }
-}
-
-function isStructuralType(typeId: string): boolean {
-  return STRUCTURAL_TYPES.has(typeId) || parseSparseArrayTypeId(typeId) !== undefined;
-}
-
-function parseSparseArrayTypeId(typeId: string): number | undefined {
-  if (!typeId.startsWith("array:")) return undefined;
-
-  const rawLength = typeId.slice("array:".length);
-  if (!/^(?:0|[1-9]\d*)$/.test(rawLength)) return undefined;
-
-  const length = Number(rawLength);
-  if (!Number.isSafeInteger(length) || length > MAX_SPARSE_ARRAY_LENGTH) return undefined;
-
-  return length;
 }
 
 function createSparseArray(length: number): unknown[] {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,3 +1,4 @@
+import { validateKnownTypeId, validateKnownTypeIds } from "./metadata.ts";
 import { MAX_SPARSE_ARRAY_LENGTH, appendIndex, appendKey } from "./path.ts";
 import { createTypeRegistry, findHandler, type TypeHandlerList } from "./types.ts";
 
@@ -26,17 +27,17 @@ export function encode<T>(input: T, options?: EncodeOptions): [string, string][]
 
   // HTMLFormElement
   if (typeof HTMLFormElement !== "undefined" && input instanceof HTMLFormElement) {
-    return encodeForm(input, typesKey, options?.types, options?.submitter);
+    return encodeForm(input, typesKey, registry, options?.types, options?.submitter);
   }
 
   // FormData
   if (typeof FormData !== "undefined" && input instanceof FormData) {
-    return encodeStringEntries(input, typesKey, options?.types);
+    return encodeStringEntries(input, typesKey, registry, options?.types);
   }
 
   // URLSearchParams
   if (typeof URLSearchParams !== "undefined" && input instanceof URLSearchParams) {
-    return encodeStringEntries(input, typesKey, options?.types);
+    return encodeStringEntries(input, typesKey, registry, options?.types);
   }
 
   // Plain value (existing behavior)
@@ -92,6 +93,7 @@ function isDisabledByFieldset(element: Element): boolean {
 function encodeForm(
   form: HTMLFormElement,
   typesKey: string,
+  registry: ReturnType<typeof createTypeRegistry>,
   explicitTypes?: Record<string, string>,
   submitter?: HTMLElement | null,
 ): [string, string][] {
@@ -126,6 +128,7 @@ function encodeForm(
     }
 
     const typeId = (el as HTMLInputElement).dataset?.sfType ?? types[el.name];
+    if (typeId) validateKnownTypeId(el.name, typeId, registry);
 
     if (el instanceof HTMLSelectElement && el.multiple) {
       for (const opt of el.selectedOptions) {
@@ -165,6 +168,7 @@ function encodeForm(
   }
 
   if (Object.keys(types).length > 0) {
+    validateKnownTypeIds(types, registry);
     entries.push([typesKey, JSON.stringify(types)]);
   }
 
@@ -174,6 +178,7 @@ function encodeForm(
 function encodeStringEntries(
   data: Iterable<[string, string | File]>,
   typesKey: string,
+  registry: ReturnType<typeof createTypeRegistry>,
   explicitTypes?: Record<string, string>,
 ): [string, string][] {
   const entries: [string, string][] = [];
@@ -199,6 +204,7 @@ function encodeStringEntries(
   const types = { ...existingTypes, ...explicitTypes };
 
   if (Object.keys(types).length > 0) {
+    validateKnownTypeIds(types, registry);
     entries.push([typesKey, JSON.stringify(types)]);
   }
 

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,4 +1,4 @@
-import { validateKnownTypeId, validateKnownTypeIds } from "./metadata.ts";
+import { validateKnownTypeIds } from "./metadata.ts";
 import { MAX_SPARSE_ARRAY_LENGTH, appendIndex, appendKey } from "./path.ts";
 import { createTypeRegistry, findHandler, type TypeHandlerList } from "./types.ts";
 
@@ -128,7 +128,6 @@ function encodeForm(
     }
 
     const typeId = (el as HTMLInputElement).dataset?.sfType ?? types[el.name];
-    if (typeId) validateKnownTypeId(el.name, typeId, registry);
 
     if (el instanceof HTMLSelectElement && el.multiple) {
       for (const opt of el.selectedOptions) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,33 @@
+import { MAX_SPARSE_ARRAY_LENGTH } from "./path.ts";
+import { getHandler, type TypeRegistry } from "./types.ts";
+
+const STRUCTURAL_TYPES = new Set(["set", "map", "array", "object"]);
+
+export function validateKnownTypeIds(types: Record<string, string>, registry: TypeRegistry): void {
+  for (const [path, typeId] of Object.entries(types)) {
+    validateKnownTypeId(path, typeId, registry);
+  }
+}
+
+export function validateKnownTypeId(path: string, typeId: string, registry: TypeRegistry): void {
+  if (isStructuralType(typeId)) return;
+  if (getHandler(typeId, registry)) return;
+
+  throw new TypeError(`Unknown type id "${typeId}" for typed field "${path}"`);
+}
+
+export function isStructuralType(typeId: string): boolean {
+  return STRUCTURAL_TYPES.has(typeId) || parseSparseArrayTypeId(typeId) !== undefined;
+}
+
+export function parseSparseArrayTypeId(typeId: string): number | undefined {
+  if (!typeId.startsWith("array:")) return undefined;
+
+  const rawLength = typeId.slice("array:".length);
+  if (!/^(?:0|[1-9]\d*)$/.test(rawLength)) return undefined;
+
+  const length = Number(rawLength);
+  if (!Number.isSafeInteger(length) || length > MAX_SPARSE_ARRAY_LENGTH) return undefined;
+
+  return length;
+}

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -52,6 +52,18 @@ describe("onChange handlers", () => {
     expect(JSON.parse(typesInput!.value)).toEqual({ count: "number" });
   });
 
+  test("onChange rejects unknown type ids before updating form metadata", () => {
+    const form = createForm('<input name="count" type="number" />');
+    const input = form.querySelector<HTMLInputElement>('input[name="count"]')!;
+    const handler = onChange("missing");
+
+    expect(() => handler({ target: input } as unknown as Event)).toThrow(
+      'Unknown type id "missing" for typed field "count"',
+    );
+    expect(input.dataset.sfType).toBeUndefined();
+    expect(form.querySelector<HTMLInputElement>('input[name="$types"]')).toBeNull();
+  });
+
   test("onDateChange", () => {
     const form = createForm('<input name="createdAt" type="date" />');
     const input = form.querySelector<HTMLInputElement>('input[name="createdAt"]')!;
@@ -221,6 +233,20 @@ describe("encode(form)", () => {
     const types = JSON.parse(typesEntry![1]);
     expect(types.count).toBe("number");
     expect(types.createdAt).toBe("Date");
+  });
+
+  test("rejects unknown data-sf-type values with the field name", () => {
+    const form = createForm('<input name="count" data-sf-type="missing" value="42" />');
+
+    expect(() => encode(form)).toThrow('Unknown type id "missing" for typed field "count"');
+  });
+
+  test("rejects unknown explicit type values with the field name", () => {
+    const form = createForm('<input name="count" value="42" />');
+
+    expect(() => encode(form, { types: { count: "missing" } })).toThrow(
+      'Unknown type id "missing" for typed field "count"',
+    );
   });
 
   test("encodes checkbox with boolean type", () => {
@@ -489,6 +515,23 @@ describe("encode(FormData)", () => {
     const typesEntry = entries.find(([k]) => k === "$types");
     expect(typesEntry).toBeDefined();
     expect(JSON.parse(typesEntry![1]).count).toBe("number");
+  });
+
+  test("rejects unknown existing $types values with the field name", () => {
+    const fd = new FormData();
+    fd.append("count", "42");
+    fd.append("$types", JSON.stringify({ count: "missing" }));
+
+    expect(() => encode(fd)).toThrow('Unknown type id "missing" for typed field "count"');
+  });
+
+  test("rejects unknown explicit types with the field name", () => {
+    const fd = new FormData();
+    fd.append("count", "42");
+
+    expect(() => encode(fd, { types: { count: "missing" } })).toThrow(
+      'Unknown type id "missing" for typed field "count"',
+    );
   });
 
   test("explicit types override existing $types", () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -64,6 +64,24 @@ describe("onChange handlers", () => {
     expect(form.querySelector<HTMLInputElement>('input[name="$types"]')).toBeNull();
   });
 
+  test("onChange accepts custom type ids when matching type handlers are provided", () => {
+    const customTypeHandler: TypeHandler<string> = {
+      id: "Currency",
+      test: (value): value is string => typeof value === "string",
+      serialize: String,
+      deserialize: (raw) => raw,
+    };
+    const form = createForm('<input name="amount" type="text" />');
+    const input = form.querySelector<HTMLInputElement>('input[name="amount"]')!;
+    const handler = onChange("Currency", { typeHandlers: [customTypeHandler] });
+
+    handler({ target: input } as unknown as Event);
+
+    expect(input.dataset.sfType).toBe("Currency");
+    const types = JSON.parse(form.querySelector<HTMLInputElement>('input[name="$types"]')!.value);
+    expect(types).toEqual({ amount: "Currency" });
+  });
+
   test("onDateChange", () => {
     const form = createForm('<input name="createdAt" type="date" />');
     const input = form.querySelector<HTMLInputElement>('input[name="createdAt"]')!;


### PR DESCRIPTION
## Summary

Fixes #47.

This PR validates type metadata at encode-time so unknown type ids fail close to the source instead of being emitted into `$types` and discovered later during decode.

## Changes

- Added shared metadata helpers for known type id validation and structural type detection.
- Reused the shared validator from `decode()` to keep decode behavior unchanged.
- Validated `encode(form)` metadata from `data-sf-type` and `options.types` with field-aware errors.
- Validated `encode(FormData)` and `encode(URLSearchParams)` metadata from existing `$types` and `options.types`.
- Validated client `onChange(typeId)` before mutating `data-sf-type` or hidden `$types` metadata.
- Added `typeHandlers` support to `ChangeHandlerOptions` so custom client type ids can be validated without breaking existing custom handler users.
- Removed redundant per-element validation in `encodeForm` and rely on the final metadata validation pass.
- Added regression coverage for unknown ids and custom client type handlers.
- Added a patch changeset.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`
