### PR TITLE
feat: add opt-in file preservation strategy

### DIFF
--- a/.changeset/preserve-file-entries.md
+++ b/.changeset/preserve-file-entries.md
@@ -1,0 +1,5 @@
+---
+"superformdata": minor
+---
+
+Add an opt-in `files: "preserve"` strategy for preserving `File` entries while encoding and decoding typed scalar form data.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ const value = decode<{
 }>(entries, { files: "preserve" });
 ```
 
-The same option works with `encode(form)` for `<input type="file">` controls and with `decodeRequest()` for multipart requests. Without `{ files: "preserve" }`, file inputs and file entries continue to throw.
+The same option works with `encode(form)` for `<input type="file">` controls, plain object `File` values, and `decodeRequest()` for multipart requests. Without `{ files: "preserve" }`, file inputs and file entries continue to throw.
 
 ## Decode a Request
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ decode([
 // => { tags: ["a", "b"] }
 ```
 
+## File and Blob Entries
+
+`superformdata` rejects `File` entries by default. This keeps binary uploads explicit and prevents accidental attempts to decode files as typed scalar fields.
+
+Pass `{ files: "preserve" }` when you want to send typed scalar fields alongside file uploads.
+
+```ts
+import { decode, encode } from "superformdata";
+
+const formData = new FormData();
+formData.append("title", "Quarterly report");
+formData.append("views", "1200");
+formData.append("attachment", new File(["content"], "report.txt"));
+
+const entries = encode(formData, {
+  files: "preserve",
+  types: { views: "number" },
+});
+// entries is typed as [string, string | File][]
+
+const value = decode<{
+  title: string;
+  views: number;
+  attachment: File;
+}>(entries, { files: "preserve" });
+```
+
+The same option works with `encode(form)` for `<input type="file">` controls and with `decodeRequest()` for multipart requests. Without `{ files: "preserve" }`, file inputs and file entries continue to throw.
+
 ## Decode a Request
 
 ```ts
@@ -278,9 +307,10 @@ document.querySelector('input[name="homepage"]')?.addEventListener("change", onU
 ## API
 
 ```ts
-encode<T>(input: T, options?: { typesKey?: string; types?: Record<string, string>; typeHandlers?: readonly TypeHandler[] }): [string, string][]
-decode<T = unknown>(data: FormData | Iterable<[string, FormDataEntryValue]>, options?: { typesKey?: string; typeHandlers?: readonly TypeHandler[] }): T
-decodeRequest<T = unknown>(request: Request, options?: { typesKey?: string; typeHandlers?: readonly TypeHandler[] }): Promise<T>
+encode<T>(input: T, options?: { typesKey?: string; types?: Record<string, string>; typeHandlers?: readonly TypeHandler[]; files?: "throw" | "preserve" }): [string, string][]
+encode<T>(input: T, options: { files: "preserve"; typesKey?: string; types?: Record<string, string>; typeHandlers?: readonly TypeHandler[] }): [string, string | File][]
+decode<T = unknown>(data: FormData | Iterable<[string, FormDataEntryValue]>, options?: { typesKey?: string; typeHandlers?: readonly TypeHandler[]; files?: "throw" | "preserve" }): T
+decodeRequest<T = unknown>(request: Request, options?: { typesKey?: string; typeHandlers?: readonly TypeHandler[]; files?: "throw" | "preserve" }): Promise<T>
 onChange(typeId: string, options?: { typesKey?: string }): (event: Event) => void
 ```
 

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -19,6 +19,11 @@ interface StructuralPath {
 export interface DecodeOptions {
   typesKey?: string;
   typeHandlers?: TypeHandlerList;
+  /**
+   * File and Blob values are rejected by default so callers do not accidentally
+   * treat binary uploads as typed scalar data.
+   */
+  files?: "throw" | "preserve";
 }
 
 export function decode<T = unknown>(
@@ -27,14 +32,23 @@ export function decode<T = unknown>(
 ): T {
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
   const raw: [string, string][] = [];
+  const preservedRaw: ParsedPathEntry[] = [];
   let typesJson: string | undefined;
   const registry = createTypeRegistry(options?.typeHandlers);
+  const fileStrategy = options?.files ?? "throw";
 
   for (const [key, value] of data) {
     if (typeof value !== "string") {
-      throw new TypeError(
-        `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately.`,
-      );
+      if (fileStrategy !== "preserve") {
+        throw new TypeError(
+          `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately or pass { files: "preserve" }.`,
+        );
+      }
+      if (key === typesKey) {
+        throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be a string`);
+      }
+      preservedRaw.push({ path: key, segments: parsePath(key), value });
+      continue;
     }
     if (key === typesKey) {
       typesJson = value;
@@ -65,7 +79,7 @@ export function decode<T = unknown>(
   }
 
   // Deserialize leaf values
-  const deserialized: ParsedPathEntry[] = [];
+  const deserialized: ParsedPathEntry[] = [...preservedRaw];
   for (const [path, value] of raw) {
     const typeId = types[path];
     const segments = parsePath(path);

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -60,11 +60,11 @@ export function encode<T>(
   }
 
   // Plain value (existing behavior)
-  const entries: EncodedEntry[] = [];
+  const entries: PreservedFileEntry[] = [];
   const types: Record<string, string> = {};
   const seen = new Set<unknown>();
 
-  walk(input, "", entries, types, seen, registry);
+  walk(input, "", entries, types, seen, registry, fileStrategy, typesKey);
 
   if (Object.keys(types).length > 0) {
     entries.push([typesKey, JSON.stringify(types)]);
@@ -215,6 +215,9 @@ function encodeStringEntries(
           `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately or pass { files: "preserve" }.`,
         );
       }
+      if (key === typesKey) {
+        throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be a string`);
+      }
       entries.push([key, value]);
       continue;
     }
@@ -252,20 +255,39 @@ function trackRef(value: unknown, path: string, seen: Set<unknown>): void {
   seen.add(value);
 }
 
+function isFileValue(value: unknown): value is File {
+  return typeof File !== "undefined" && value instanceof File;
+}
+
 function walk(
   value: unknown,
   path: string,
-  entries: [string, string][],
+  entries: PreservedFileEntry[],
   types: Record<string, string>,
   seen: Set<unknown>,
   registry: ReturnType<typeof createTypeRegistry>,
+  fileStrategy: FileStrategy,
+  typesKey: string,
 ): void {
+  if (isFileValue(value)) {
+    if (fileStrategy !== "preserve") {
+      throw new TypeError(
+        `File values are not supported by superformdata at path "${path}". Handle file uploads separately or pass { files: "preserve" }.`,
+      );
+    }
+    if (path === typesKey) {
+      throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be a string`);
+    }
+    entries.push([path, value]);
+    return;
+  }
+
   if (value instanceof Set) {
     trackRef(value, path, seen);
     types[path] = "set";
     let i = 0;
     for (const item of value) {
-      walk(item, appendIndex(path, i), entries, types, seen, registry);
+      walk(item, appendIndex(path, i), entries, types, seen, registry, fileStrategy, typesKey);
       i++;
     }
     seen.delete(value);
@@ -277,8 +299,26 @@ function walk(
     types[path] = "map";
     let i = 0;
     for (const [k, v] of value) {
-      walk(k, appendIndex(appendIndex(path, i), 0), entries, types, seen, registry);
-      walk(v, appendIndex(appendIndex(path, i), 1), entries, types, seen, registry);
+      walk(
+        k,
+        appendIndex(appendIndex(path, i), 0),
+        entries,
+        types,
+        seen,
+        registry,
+        fileStrategy,
+        typesKey,
+      );
+      walk(
+        v,
+        appendIndex(appendIndex(path, i), 1),
+        entries,
+        types,
+        seen,
+        registry,
+        fileStrategy,
+        typesKey,
+      );
       i++;
     }
     seen.delete(value);
@@ -300,7 +340,7 @@ function walk(
         types[path] = `array:${value.length}`;
         continue;
       }
-      walk(value[i], appendIndex(path, i), entries, types, seen, registry);
+      walk(value[i], appendIndex(path, i), entries, types, seen, registry, fileStrategy, typesKey);
     }
     seen.delete(value);
     return;
@@ -325,7 +365,16 @@ function walk(
       return;
     }
     for (const key of keys) {
-      walk(value[key], appendKey(path, key), entries, types, seen, registry);
+      walk(
+        value[key],
+        appendKey(path, key),
+        entries,
+        types,
+        seen,
+        registry,
+        fileStrategy,
+        typesKey,
+      );
     }
     seen.delete(value);
     return;

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -4,10 +4,19 @@ import { createTypeRegistry, findHandler, type TypeHandlerList } from "./types.t
 
 export const DEFAULT_TYPES_KEY = "$types";
 
+export type EncodedEntry = [string, string];
+export type PreservedFileEntry = [string, string | File];
+export type FileStrategy = "throw" | "preserve";
+
 export interface EncodeOptions {
   typesKey?: string;
   types?: Record<string, string>;
   typeHandlers?: TypeHandlerList;
+  /**
+   * File and Blob values are rejected by default so callers do not accidentally
+   * treat binary uploads as typed scalar data.
+   */
+  files?: FileStrategy;
   /**
    * The element used to submit the form, mirroring `new FormData(form, submitter)`.
    * Only submit buttons (`<button>`, `input[type=submit]`) that equal this element
@@ -21,27 +30,37 @@ export interface EncodeOptions {
   submitter?: HTMLElement | null;
 }
 
-export function encode<T>(input: T, options?: EncodeOptions): [string, string][] {
+export interface EncodePreserveFilesOptions extends EncodeOptions {
+  files: "preserve";
+}
+
+export function encode<T>(input: T, options: EncodePreserveFilesOptions): PreservedFileEntry[];
+export function encode<T>(input: T, options?: EncodeOptions): EncodedEntry[];
+export function encode<T>(
+  input: T,
+  options?: EncodeOptions,
+): EncodedEntry[] | PreservedFileEntry[] {
   const typesKey = options?.typesKey ?? DEFAULT_TYPES_KEY;
   const registry = createTypeRegistry(options?.typeHandlers);
+  const fileStrategy = options?.files ?? "throw";
 
   // HTMLFormElement
   if (typeof HTMLFormElement !== "undefined" && input instanceof HTMLFormElement) {
-    return encodeForm(input, typesKey, registry, options?.types, options?.submitter);
+    return encodeForm(input, typesKey, registry, fileStrategy, options?.types, options?.submitter);
   }
 
   // FormData
   if (typeof FormData !== "undefined" && input instanceof FormData) {
-    return encodeStringEntries(input, typesKey, registry, options?.types);
+    return encodeStringEntries(input, typesKey, registry, fileStrategy, options?.types);
   }
 
   // URLSearchParams
   if (typeof URLSearchParams !== "undefined" && input instanceof URLSearchParams) {
-    return encodeStringEntries(input, typesKey, registry, options?.types);
+    return encodeStringEntries(input, typesKey, registry, fileStrategy, options?.types);
   }
 
   // Plain value (existing behavior)
-  const entries: [string, string][] = [];
+  const entries: EncodedEntry[] = [];
   const types: Record<string, string> = {};
   const seen = new Set<unknown>();
 
@@ -94,10 +113,11 @@ function encodeForm(
   form: HTMLFormElement,
   typesKey: string,
   registry: ReturnType<typeof createTypeRegistry>,
+  fileStrategy: FileStrategy,
   explicitTypes?: Record<string, string>,
   submitter?: HTMLElement | null,
-): [string, string][] {
-  const entries: [string, string][] = [];
+): EncodedEntry[] | PreservedFileEntry[] {
+  const entries: PreservedFileEntry[] = [];
   const types: Record<string, string> = { ...explicitTypes };
 
   for (const element of form.elements) {
@@ -157,9 +177,13 @@ function encodeForm(
     }
 
     if (input.type === "file") {
-      throw new TypeError(
-        `File inputs are not supported by superformdata (field: "${input.name}"). Handle file uploads separately.`,
-      );
+      if (fileStrategy !== "preserve") {
+        throw new TypeError(
+          `File inputs are not supported by superformdata (field: "${input.name}"). Handle file uploads separately or pass { files: "preserve" }.`,
+        );
+      }
+      for (const file of input.files ?? []) entries.push([input.name, file]);
+      continue;
     }
 
     entries.push([el.name, input.value]);
@@ -178,16 +202,21 @@ function encodeStringEntries(
   data: Iterable<[string, string | File]>,
   typesKey: string,
   registry: ReturnType<typeof createTypeRegistry>,
+  fileStrategy: FileStrategy,
   explicitTypes?: Record<string, string>,
-): [string, string][] {
-  const entries: [string, string][] = [];
+): EncodedEntry[] | PreservedFileEntry[] {
+  const entries: PreservedFileEntry[] = [];
   let existingTypes: Record<string, string> | undefined;
 
   for (const [key, value] of data) {
     if (typeof value !== "string") {
-      throw new TypeError(
-        `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately.`,
-      );
+      if (fileStrategy !== "preserve") {
+        throw new TypeError(
+          `File entries are not supported by superformdata (field: "${key}"). Handle file uploads separately or pass { files: "preserve" }.`,
+        );
+      }
+      entries.push([key, value]);
+      continue;
     }
     if (key === typesKey) {
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,12 @@ export {
   onURLChange,
 } from "./client.ts";
 export type { ChangeHandlerOptions, ChangeHandlers } from "./client.ts";
-export type { EncodeOptions } from "./encode.ts";
+export type {
+  EncodedEntry,
+  EncodeOptions,
+  EncodePreserveFilesOptions,
+  FileStrategy,
+  PreservedFileEntry,
+} from "./encode.ts";
 export type { DecodeOptions } from "./decode.ts";
 export type { TypeHandler, TypeHandlerList } from "./types.ts";

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -639,4 +639,13 @@ describe("encode(FormData)", () => {
       count: "number",
     });
   });
+
+  test("throws when preserved File entry uses the metadata key", () => {
+    const fd = new FormData();
+    fd.append("$types", new File(["content"], "metadata.txt"));
+
+    expect(() => encode(fd, { files: "preserve" })).toThrow(
+      'Invalid superformdata metadata: "$types" field must be a string',
+    );
+  });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -404,6 +404,23 @@ describe("encode(form)", () => {
     expect(() => encode(form)).toThrow(/File inputs are not supported/);
   });
 
+  test('preserves file inputs when files option is "preserve"', () => {
+    const form = createForm('<input name="name" value="Alice" /><input name="file" type="file" />');
+    const input = form.querySelector<HTMLInputElement>('input[type="file"]')!;
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+
+    Object.defineProperty(input, "files", {
+      value: [file],
+    });
+
+    const entries = encode(form, { files: "preserve" });
+
+    expect(entries).toEqual([
+      ["name", "Alice"],
+      ["file", file],
+    ]);
+  });
+
   test("encodes with custom typesKey", () => {
     const form = createForm('<input name="count" data-sf-type="number" value="42" />');
     const entries = encode(form, { typesKey: "__meta" });
@@ -604,5 +621,22 @@ describe("encode(FormData)", () => {
     fd.append("file", new File(["content"], "test.txt"));
 
     expect(() => encode(fd)).toThrow(/File entries are not supported/);
+  });
+
+  test('preserves File entries when files option is "preserve"', () => {
+    const fd = new FormData();
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+    fd.append("name", "Alice");
+    fd.append("file", file);
+    fd.append("count", "42");
+
+    const entries = encode(fd, { files: "preserve", types: { count: "number" } });
+
+    expect(entries).toContainEqual(["name", "Alice"]);
+    expect(entries).toContainEqual(["file", file]);
+    expect(entries).toContainEqual(["count", "42"]);
+    expect(JSON.parse(entries.find(([key]) => key === "$types")![1] as string)).toEqual({
+      count: "number",
+    });
   });
 });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -515,6 +515,28 @@ describe("encode/decode round-trip", () => {
     expect(result.b.source).toBe("test");
   });
 
+  test('encode preserves File values in plain objects when files option is "preserve"', () => {
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+
+    expect(encode({ attachment: file }, { files: "preserve" })).toEqual([["attachment", file]]);
+  });
+
+  test("encode throws a file-specific error for plain object File values by default", () => {
+    const file = new File(["content"], "test.txt");
+
+    expect(() => encode({ attachment: file })).toThrow(
+      'File values are not supported by superformdata at path "attachment"',
+    );
+  });
+
+  test("encode throws when a preserved plain object File value uses the metadata key", () => {
+    const file = new File(["content"], "metadata.txt");
+
+    expect(() => encode({ $types: file }, { files: "preserve" })).toThrow(
+      'Invalid superformdata metadata: "$types" field must be a string',
+    );
+  });
+
   test("decode with no entries returns empty object", () => {
     expect(decode<Record<string, never>>([])).toEqual({});
   });

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -567,6 +567,35 @@ describe("encode/decode round-trip", () => {
     expect(() => decode(formData)).toThrow(/File entries are not supported/);
   });
 
+  test('decode preserves File entries when files option is "preserve"', () => {
+    const formData = new FormData();
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+    formData.append("name", "Alice");
+    formData.append("file", file);
+    formData.append("age", "30");
+    formData.append("$types", JSON.stringify({ age: "number" }));
+
+    expect(
+      decode<{ name: string; file: File; age: number }>(formData, { files: "preserve" }),
+    ).toEqual({
+      name: "Alice",
+      file,
+      age: 30,
+    });
+  });
+
+  test('decode preserves repeated File entries when files option is "preserve"', () => {
+    const formData = new FormData();
+    const first = new File(["first"], "first.txt");
+    const second = new File(["second"], "second.txt");
+    formData.append("attachments", first);
+    formData.append("attachments", second);
+
+    expect(decode<{ attachments: File[] }>(formData, { files: "preserve" })).toEqual({
+      attachments: [first, second],
+    });
+  });
+
   test("decode from FormData", () => {
     const original = { name: "Alice", age: 30 };
     const entries = encode(original);

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -14,6 +14,12 @@ const encoded = encode({
 
 type _EncodeReturnIsStable = Assert<Equal<typeof encoded, [string, string][]>>;
 
+const encodedWithFiles = encode(new FormData(), { files: "preserve" });
+
+type _EncodePreserveFilesReturnIncludesFiles = Assert<
+  Equal<typeof encodedWithFiles, [string, string | File][]>
+>;
+
 const decoded = decode<{
   createdAt: Date;
   active: boolean;


### PR DESCRIPTION
## Summary

Closes #48.

Adds an explicit opt-in strategy for preserving file entries while keeping the existing default safety behavior:

- adds `files: "preserve"` to `encode()` for `FormData` and `HTMLFormElement` inputs
- adds `files: "preserve"` to `decode()`/`decodeRequest()` so `File` values can be preserved in decoded output
- keeps the default behavior throwing on file inputs and non-string entries
- adds overloads/types so default `encode()` remains `[string, string][]`, while opt-in file preservation returns `[string, string | File][]`
- documents the file strategy and adds a changeset

## Tests

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run check`
