### PR TITLE
[codex] Reject malformed paths and metadata

### DIFF
--- a/.changeset/strict-decode-metadata.md
+++ b/.changeset/strict-decode-metadata.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject malformed decoded paths, duplicate metadata fields, and invalid existing metadata passed through `encode()`.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,5 +1,10 @@
 import { DEFAULT_TYPES_KEY } from "./encode.ts";
-import { isStructuralType, parseSparseArrayTypeId, validateKnownTypeIds } from "./metadata.ts";
+import {
+  isStructuralType,
+  parseSparseArrayTypeId,
+  validateKnownTypeIds,
+  validateTypesMetadata,
+} from "./metadata.ts";
 import {
   appendIndex,
   appendKey,
@@ -51,6 +56,9 @@ export function decode<T = unknown>(
       continue;
     }
     if (key === typesKey) {
+      if (typesJson !== undefined) {
+        throw new TypeError(`Invalid superformdata metadata: duplicate "${typesKey}" field`);
+      }
       typesJson = value;
     } else {
       raw.push([key, value]);
@@ -164,23 +172,6 @@ export function decode<T = unknown>(
   }
 
   return result as T;
-}
-
-function validateTypesMetadata(
-  types: unknown,
-  typesKey: string,
-): asserts types is Record<string, string> {
-  if (types === null || typeof types !== "object" || Array.isArray(types)) {
-    throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be an object`);
-  }
-
-  for (const [path, typeId] of Object.entries(types)) {
-    if (typeof typeId !== "string") {
-      throw new TypeError(
-        `Invalid superformdata metadata: "${typesKey}" field must map paths to string type ids (path: "${path}")`,
-      );
-    }
-  }
 }
 
 function createSparseArray(length: number): unknown[] {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,4 +1,4 @@
-import { validateKnownTypeIds } from "./metadata.ts";
+import { validateKnownTypeIds, validateTypesMetadata } from "./metadata.ts";
 import { MAX_SPARSE_ARRAY_LENGTH, appendIndex, appendKey } from "./path.ts";
 import { createTypeRegistry, findHandler, type TypeHandlerList } from "./types.ts";
 
@@ -222,11 +222,17 @@ function encodeStringEntries(
       continue;
     }
     if (key === typesKey) {
+      if (existingTypes !== undefined) {
+        throw new TypeError(`Invalid superformdata metadata: duplicate "${typesKey}" field`);
+      }
       try {
         existingTypes = JSON.parse(value);
       } catch {
-        // Malformed $types — ignore and treat entries as strings
+        throw new TypeError(
+          `Invalid superformdata metadata: "${typesKey}" field contains malformed JSON`,
+        );
       }
+      validateTypesMetadata(existingTypes, typesKey);
       continue;
     }
     entries.push([key, value]);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -9,6 +9,23 @@ export function validateKnownTypeIds(types: Record<string, string>, registry: Ty
   }
 }
 
+export function validateTypesMetadata(
+  types: unknown,
+  typesKey: string,
+): asserts types is Record<string, string> {
+  if (types === null || typeof types !== "object" || Array.isArray(types)) {
+    throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be an object`);
+  }
+
+  for (const [path, typeId] of Object.entries(types)) {
+    if (typeof typeId !== "string") {
+      throw new TypeError(
+        `Invalid superformdata metadata: "${typesKey}" field must map paths to string type ids (path: "${path}")`,
+      );
+    }
+  }
+}
+
 export function validateKnownTypeId(path: string, typeId: string, registry: TypeRegistry): void {
   if (isStructuralType(typeId)) return;
   if (getHandler(typeId, registry)) return;

--- a/src/path.ts
+++ b/src/path.ts
@@ -132,10 +132,7 @@ export function parsePath(path: string): PathSegment[] {
         hasCurrentSegment = true;
         i += 2;
       } else {
-        // Trailing backslash — treat as literal
-        current += "\\";
-        hasCurrentSegment = true;
-        i++;
+        throw new TypeError(`Invalid path "${path}": trailing escape character`);
       }
     } else if (path[i] === ".") {
       segments.push(current);
@@ -150,10 +147,7 @@ export function parsePath(path: string): PathSegment[] {
       }
       const close = path.indexOf("]", i);
       if (close === -1) {
-        // Malformed bracket — treat rest as literal
-        current += path.slice(i);
-        hasCurrentSegment = true;
-        break;
+        throw new TypeError(`Invalid path "${path}": missing closing bracket`);
       }
       segments.push(parseArrayIndex(path.slice(i + 1, close), path));
       i = close + 1;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -580,6 +580,15 @@ describe("encode(FormData)", () => {
     expect(types.val).toBe("number");
   });
 
+  test("throws on duplicate existing $types entries", () => {
+    const fd = new FormData();
+    fd.append("count", "42");
+    fd.append("$types", JSON.stringify({ count: "number" }));
+    fd.append("$types", JSON.stringify({ count: "bigint" }));
+
+    expect(() => encode(fd)).toThrow('Invalid superformdata metadata: duplicate "$types" field');
+  });
+
   test("FormData without types returns plain entries", () => {
     const fd = new FormData();
     fd.append("name", "Alice");

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -114,12 +114,16 @@ describe("parsePath", () => {
     expect(parsePath("a.b[0].c[1].d")).toEqual(["a", "b", 0, "c", 1, "d"]);
   });
 
-  test("trailing backslash", () => {
-    expect(parsePath("key\\")).toEqual(["key\\"]);
+  test("rejects trailing backslash", () => {
+    expect(() => parsePath("key\\")).toThrow(
+      new TypeError('Invalid path "key\\": trailing escape character'),
+    );
   });
 
-  test("missing closing bracket", () => {
-    expect(parsePath("items[0")).toEqual(["items", "[0"]);
+  test("rejects missing closing bracket", () => {
+    expect(() => parsePath("items[0")).toThrow(
+      new TypeError('Invalid path "items[0": missing closing bracket'),
+    );
   });
 
   test("empty string key (a..b)", () => {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -354,6 +354,24 @@ describe("encode/decode round-trip", () => {
     ]);
   });
 
+  test("URLSearchParams encode throws on malformed existing metadata", () => {
+    const params = new URLSearchParams("count=42");
+    params.set("$types", "not json");
+
+    expect(() => encode(params)).toThrow(
+      'Invalid superformdata metadata: "$types" field contains malformed JSON',
+    );
+  });
+
+  test("URLSearchParams encode throws on invalid existing metadata shape", () => {
+    const params = new URLSearchParams("count=42");
+    params.set("$types", JSON.stringify({ count: 30 }));
+
+    expect(() => encode(params)).toThrow(
+      'Invalid superformdata metadata: "$types" field must map paths to string type ids (path: "count")',
+    );
+  });
+
   test("nested invalid Date throws path-aware TypeError", () => {
     expect(() => encode({ post: { publishedAt: new Date("not-a-date") } })).toThrow(
       new TypeError('Invalid Date at path "post.publishedAt"'),
@@ -422,6 +440,15 @@ describe("encode/decode round-trip", () => {
 
   test("decode rejects array indexes that would create sparse arrays", () => {
     expect(() => decode([["a[100000000]", "x"]])).toThrow("Array index too large");
+  });
+
+  test("decode rejects malformed path syntax", () => {
+    expect(() => decode([["items[0", "x"]])).toThrow(
+      'Invalid path "items[0": missing closing bracket',
+    );
+    expect(() => decode([["name\\", "x"]])).toThrow(
+      'Invalid path "name\\": trailing escape character',
+    );
   });
 
   test("object with numeric string keys", () => {
@@ -555,6 +582,16 @@ describe("encode/decode round-trip", () => {
         ["$types", "not json"],
       ]),
     ).toThrow("malformed JSON");
+  });
+
+  test("decode throws on duplicate $types metadata", () => {
+    expect(() =>
+      decode([
+        ["count", "42"],
+        ["$types", JSON.stringify({ count: "number" })],
+        ["$types", JSON.stringify({ count: "bigint" })],
+      ]),
+    ).toThrow('Invalid superformdata metadata: duplicate "$types" field');
   });
 
   test("decode throws on non-object $types metadata", () => {


### PR DESCRIPTION
## Summary

Closes #49.

This makes decoded input handling stricter before the API stabilizes. Malformed path syntax now fails early instead of being interpreted as literal key text, duplicate metadata fields are rejected, and `encode()` now validates existing metadata that it forwards from `FormData` or `URLSearchParams`.

## Root Cause

`parsePath()` had permissive fallbacks for unterminated bracket syntax and trailing escape characters, so ambiguous paths could be decoded as literal object keys. Separately, `decode()` overwrote earlier `$types` fields with last-one-wins behavior, and `encodeStringEntries()` ignored malformed existing `$types` JSON while `decode()` rejected it.

## Changes

- Reject trailing path escape characters and missing closing brackets with path-specific `TypeError`s.
- Reject duplicate `$types` metadata in both decode and existing string-entry encode flows.
- Share metadata shape validation between encode and decode so malformed existing metadata is handled consistently.
- Add regression coverage for malformed paths, duplicate metadata, and invalid existing metadata.
- Add a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun test`
- `bun typecheck`
