### PR TITLE
feat: split core and client entrypoints

### DIFF
--- a/.changeset/split-entrypoints.md
+++ b/.changeset/split-entrypoints.md
@@ -1,0 +1,5 @@
+---
+"superformdata": minor
+---
+
+Add `superformdata/core` and `superformdata/client` subpath exports while preserving the root entrypoint.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install superformdata
 ## Basic Usage
 
 ```ts
-import { decode, encode } from "superformdata";
+import { decode, encode } from "superformdata/core";
 
 const input = {
   user: {
@@ -45,7 +45,7 @@ const value = decode<typeof input>(entries);
 Serialize a rich value into form-style entries.
 
 ```ts
-import { encode } from "superformdata";
+import { encode } from "superformdata/core";
 
 const entries = encode({
   title: "Quarterly report",
@@ -69,7 +69,7 @@ console.log(entries);
 Decode `FormData` entries back into a typed value.
 
 ```ts
-import { decode } from "superformdata";
+import { decode } from "superformdata/core";
 
 const entries = [
   ["user.name", "Alice"],
@@ -104,7 +104,7 @@ decode([
 Pass `{ files: "preserve" }` when you want to send typed scalar fields alongside file uploads.
 
 ```ts
-import { decode, encode } from "superformdata";
+import { decode, encode } from "superformdata/core";
 
 const formData = new FormData();
 formData.append("title", "Quarterly report");
@@ -129,7 +129,7 @@ The same option works with `encode(form)` for `<input type="file">` controls, pl
 ## Decode a Request
 
 ```ts
-import { decodeRequest } from "superformdata";
+import { decodeRequest } from "superformdata/core";
 
 export async function POST(request: Request) {
   const data = await decodeRequest<{
@@ -146,7 +146,7 @@ export async function POST(request: Request) {
 Pass custom handlers to `encode()` and `decode()` when you need to round-trip domain-specific values.
 
 ```ts
-import { decode, encode, type TypeHandler } from "superformdata";
+import { decode, encode, type TypeHandler } from "superformdata/core";
 
 interface Money {
   readonly cents: number;
@@ -174,7 +174,7 @@ Custom handler IDs must be unique and cannot use built-in or structural IDs such
 Decode a `Request` body directly.
 
 ```ts
-import { decodeRequest } from "superformdata";
+import { decodeRequest } from "superformdata/core";
 
 export async function action(request: Request) {
   const data = await decodeRequest<{
@@ -201,7 +201,7 @@ import {
   onDateChange,
   onNumberChange,
   onURLChange,
-} from "superformdata";
+} from "superformdata/client";
 
 document.querySelector('input[name="count"]')?.addEventListener("change", onNumberChange);
 document.querySelector('input[name="createdAt"]')?.addEventListener("change", onDateChange);
@@ -216,7 +216,7 @@ document.querySelector('input[name="pattern"]')?.addEventListener("change", onCh
 Then pass the form to `encode()`:
 
 ```ts
-import { encode } from "superformdata";
+import { encode } from "superformdata/core";
 
 const form = document.querySelector("form");
 const entries = encode(form!);
@@ -239,7 +239,7 @@ The package currently recognizes `data-sf-type`.
 ```
 
 ```ts
-import { encode } from "superformdata";
+import { encode } from "superformdata/core";
 
 const form = document.querySelector<HTMLFormElement>("#post-form")!;
 const entries = encode(form);
@@ -258,7 +258,7 @@ No other `data-sf-*` attributes are currently read by the package.
 Attach your own type id to an input.
 
 ```ts
-import { onChange } from "superformdata";
+import { onChange } from "superformdata/client";
 
 const patternInput = document.querySelector<HTMLInputElement>('input[name="pattern"]')!;
 patternInput.addEventListener("change", onChange("RegExp"));
@@ -267,7 +267,7 @@ patternInput.addEventListener("change", onChange("RegExp"));
 ### `onDateChange()`
 
 ```ts
-import { onDateChange } from "superformdata";
+import { onDateChange } from "superformdata/client";
 
 document.querySelector('input[name="publishedAt"]')?.addEventListener("change", onDateChange);
 ```
@@ -275,7 +275,7 @@ document.querySelector('input[name="publishedAt"]')?.addEventListener("change", 
 ### `onNumberChange()`
 
 ```ts
-import { onNumberChange } from "superformdata";
+import { onNumberChange } from "superformdata/client";
 
 document.querySelector('input[name="price"]')?.addEventListener("change", onNumberChange);
 ```
@@ -283,7 +283,7 @@ document.querySelector('input[name="price"]')?.addEventListener("change", onNumb
 ### `onBooleanChange()`
 
 ```ts
-import { onBooleanChange } from "superformdata";
+import { onBooleanChange } from "superformdata/client";
 
 document.querySelector('input[name="completed"]')?.addEventListener("change", onBooleanChange);
 ```
@@ -291,7 +291,7 @@ document.querySelector('input[name="completed"]')?.addEventListener("change", on
 ### `onBigIntChange()`
 
 ```ts
-import { onBigIntChange } from "superformdata";
+import { onBigIntChange } from "superformdata/client";
 
 document.querySelector('input[name="orderId"]')?.addEventListener("change", onBigIntChange);
 ```
@@ -299,7 +299,7 @@ document.querySelector('input[name="orderId"]')?.addEventListener("change", onBi
 ### `onURLChange()`
 
 ```ts
-import { onURLChange } from "superformdata";
+import { onURLChange } from "superformdata/client";
 
 document.querySelector('input[name="homepage"]')?.addEventListener("change", onURLChange);
 ```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,16 @@
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "core": [
+        "dist/core.d.mts"
+      ],
+      "client": [
+        "dist/client.d.mts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,16 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./core": {
+      "types": "./dist/core.d.mts",
+      "import": "./dist/core.mjs",
+      "require": "./dist/core.cjs"
+    },
+    "./client": {
+      "types": "./dist/client.d.mts",
+      "import": "./dist/client.mjs",
+      "require": "./dist/client.cjs"
     }
   },
   "scripts": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,11 @@
+export { decode, decodeRequest } from "./decode.ts";
+export type { DecodeOptions } from "./decode.ts";
+export { encode } from "./encode.ts";
+export type {
+  EncodedEntry,
+  EncodeOptions,
+  EncodePreserveFilesOptions,
+  FileStrategy,
+  PreservedFileEntry,
+} from "./encode.ts";
+export type { TypeHandler, TypeHandlerList } from "./types.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
-export { encode } from "./encode.ts";
-export { decode, decodeRequest } from "./decode.ts";
+export {
+  decode,
+  decodeRequest,
+  encode,
+  type DecodeOptions,
+  type EncodedEntry,
+  type EncodeOptions,
+  type EncodePreserveFilesOptions,
+  type FileStrategy,
+  type PreservedFileEntry,
+  type TypeHandler,
+  type TypeHandlerList,
+} from "./core.ts";
 export {
   createChangeHandlers,
   onChange,
@@ -10,12 +21,3 @@ export {
   onURLChange,
 } from "./client.ts";
 export type { ChangeHandlerOptions, ChangeHandlers } from "./client.ts";
-export type {
-  EncodedEntry,
-  EncodeOptions,
-  EncodePreserveFilesOptions,
-  FileStrategy,
-  PreservedFileEntry,
-} from "./encode.ts";
-export type { DecodeOptions } from "./decode.ts";
-export type { TypeHandler, TypeHandlerList } from "./types.ts";

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -30,10 +30,12 @@ describe("package exports", () => {
     const core = (await import(`${packageJson.name}/core`)) as CoreEntrypoint;
     const client = (await import(`${packageJson.name}/client`)) as ClientEntrypoint;
     const require = createRequire(import.meta.url);
+    const cjsRoot = require(packageJson.name) as CoreEntrypoint;
     const cjsCore = require(`${packageJson.name}/core`) as CoreEntrypoint;
     const cjsClient = require(`${packageJson.name}/client`) as ClientEntrypoint;
 
     expect(root.encode({ count: 1 })).toContainEqual(["count", "1"]);
+    expect(cjsRoot.encode({ count: 1 })).toContainEqual(["count", "1"]);
     expect(
       core.decode<{ readonly createdAt: Date }>(
         core.encode({ createdAt: new Date("2024-01-01T00:00:00.000Z") }),
@@ -44,5 +46,72 @@ describe("package exports", () => {
     expect(client.createChangeHandlers).toBeFunction();
     expect(cjsCore.encode({ count: 1 })).toContainEqual(["count", "1"]);
     expect(cjsClient.createChangeHandlers).toBeFunction();
+  });
+
+  test('resolves subpath types with moduleResolution "node"', async () => {
+    const build = Bun.spawnSync(["bun", "run", "build"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(build.exitCode, new TextDecoder().decode(build.stderr)).toBe(0);
+
+    const workspace = await Bun.$`mktemp -d`.text();
+    const tempDir = workspace.trim();
+    const packageDir = import.meta.dir + "/..";
+
+    await Bun.$`mkdir -p ${tempDir}/node_modules`;
+    await Bun.$`ln -s ${packageDir} ${tempDir}/node_modules/${packageJson.name}`;
+
+    await Bun.write(
+      `${tempDir}/index.ts`,
+      `
+import { decode, encode, type TypeHandler } from "superformdata/core";
+import { createChangeHandlers, type ChangeHandlers } from "superformdata/client";
+
+const entries = encode({ count: 1 });
+const decoded = decode<{ readonly count: number }>(entries);
+const handlers: ChangeHandlers = createChangeHandlers();
+const typeHandler: TypeHandler<unknown> = {
+  id: "unknown",
+  test: (value): value is unknown => value !== undefined,
+  serialize: String,
+  deserialize: (raw) => raw,
+};
+
+void decoded;
+void handlers;
+void typeHandler;
+`,
+    );
+    await Bun.write(
+      `${tempDir}/tsconfig.json`,
+      JSON.stringify(
+        {
+          compilerOptions: {
+            lib: ["esnext", "dom", "dom.iterable"],
+            module: "esnext",
+            moduleResolution: "node",
+            noEmit: true,
+            strict: true,
+            target: "esnext",
+          },
+          files: ["index.ts"],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const typecheck = Bun.spawnSync(["bun", "x", "tsc", "--project", tempDir], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const output = `${new TextDecoder().decode(typecheck.stdout)}${new TextDecoder().decode(typecheck.stderr)}`;
+
+    expect(typecheck.exitCode, output).toBe(0);
   });
 });

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -3,6 +3,15 @@ import { createRequire } from "node:module";
 
 import packageJson from "../package.json" with { type: "json" };
 
+interface CoreEntrypoint {
+  readonly decode: <T = unknown>(data: Iterable<[string, FormDataEntryValue]>) => T;
+  readonly encode: (input: unknown) => [string, string][];
+}
+
+interface ClientEntrypoint {
+  readonly createChangeHandlers: () => unknown;
+}
+
 describe("package exports", () => {
   test("declares root, core, and client subpaths", () => {
     expect(Object.keys(packageJson.exports).sort()).toEqual([".", "./client", "./core"]);
@@ -17,12 +26,12 @@ describe("package exports", () => {
 
     expect(build.exitCode, new TextDecoder().decode(build.stderr)).toBe(0);
 
-    const root = await import("superformdata");
-    const core = await import("superformdata/core");
-    const client = await import("superformdata/client");
+    const root = (await import(packageJson.name)) as CoreEntrypoint;
+    const core = (await import(`${packageJson.name}/core`)) as CoreEntrypoint;
+    const client = (await import(`${packageJson.name}/client`)) as ClientEntrypoint;
     const require = createRequire(import.meta.url);
-    const cjsCore = require("superformdata/core") as typeof core;
-    const cjsClient = require("superformdata/client") as typeof client;
+    const cjsCore = require(`${packageJson.name}/core`) as CoreEntrypoint;
+    const cjsClient = require(`${packageJson.name}/client`) as ClientEntrypoint;
 
     expect(root.encode({ count: 1 })).toContainEqual(["count", "1"]);
     expect(

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+
+import packageJson from "../package.json" with { type: "json" };
+
+describe("package exports", () => {
+  test("declares root, core, and client subpaths", () => {
+    expect(Object.keys(packageJson.exports).sort()).toEqual([".", "./client", "./core"]);
+  });
+
+  test("builds and imports each public subpath", async () => {
+    const build = Bun.spawnSync(["bun", "run", "build"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(build.exitCode, new TextDecoder().decode(build.stderr)).toBe(0);
+
+    const root = await import("superformdata");
+    const core = await import("superformdata/core");
+    const client = await import("superformdata/client");
+    const require = createRequire(import.meta.url);
+    const cjsCore = require("superformdata/core") as typeof core;
+    const cjsClient = require("superformdata/client") as typeof client;
+
+    expect(root.encode({ count: 1 })).toContainEqual(["count", "1"]);
+    expect(
+      core.decode<{ readonly createdAt: Date }>(
+        core.encode({ createdAt: new Date("2024-01-01T00:00:00.000Z") }),
+      ),
+    ).toEqual({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    });
+    expect(client.createChangeHandlers).toBeFunction();
+    expect(cjsCore.encode({ count: 1 })).toContainEqual(["count", "1"]);
+    expect(cjsClient.createChangeHandlers).toBeFunction();
+  });
+});

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/core.ts", "src/client.ts"],
   format: ["esm", "cjs"],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Summary

Closes #50.

This adds dedicated package subpath exports so consumers can import the API surface they need:

- `superformdata/core` exposes `encode`, `decode`, `decodeRequest`, and shared core types.
- `superformdata/client` exposes browser form change handlers and their types.
- `superformdata` remains a compatibility aggregate that re-exports both surfaces.

## Changes

- Added `src/core.ts` as the server-safe core entrypoint.
- Updated `package.json` exports to publish root, `./core`, and `./client` with ESM, CJS, and declaration targets.
- Updated `tsdown.config.mts` to build all public entrypoints.
- Updated README examples to prefer `superformdata/core` for serialization APIs and `superformdata/client` for browser helpers.
- Added a package export smoke test that builds the package and imports each public subpath through ESM and CJS.
- Added a minor changeset for the new public subpath exports.

## Validation

- `bun run check`
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun run build`
