### PR TITLE
fix: reject empty types metadata

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -66,7 +66,7 @@ export function decode<T = unknown>(
   }
 
   let types: Record<string, string> = {};
-  if (typesJson) {
+  if (typesJson !== undefined) {
     try {
       types = JSON.parse(typesJson);
     } catch {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -584,6 +584,19 @@ describe("encode/decode round-trip", () => {
     ).toThrow("malformed JSON");
   });
 
+  test("decode throws on empty $types metadata", () => {
+    expect(() => decode([["$types", ""]])).toThrow("malformed JSON");
+  });
+
+  test("decode throws on empty $types metadata alongside normal fields", () => {
+    expect(() =>
+      decode([
+        ["name", "Alice"],
+        ["$types", ""],
+      ]),
+    ).toThrow("malformed JSON");
+  });
+
   test("decode throws on duplicate $types metadata", () => {
     expect(() =>
       decode([


### PR DESCRIPTION
Fixes #65.

Changes:
- Parse `$types` metadata when field is present but empty
- Reject malformed empty metadata instead of silently ignoring it
- Add regression tests for empty `$types`

Testing:
- bun test test/roundtrip.test.ts
- git diff --check