### PR TITLE
fix: reject ambiguous array path segments

### DIFF
--- a/.changeset/strict-array-paths.md
+++ b/.changeset/strict-array-paths.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject ambiguous key text immediately after bracketed array indexes.

--- a/src/path.ts
+++ b/src/path.ts
@@ -151,7 +151,9 @@ export function parsePath(path: string): PathSegment[] {
       }
       segments.push(parseArrayIndex(path.slice(i + 1, close), path));
       i = close + 1;
-      // skip trailing dot after bracket (e.g., `[0].name`)
+      if (i < path.length && path[i] !== "." && path[i] !== "[") {
+        throw new TypeError(`Invalid path "${path}": expected ".", "[", or end after array index`);
+      }
       if (path[i] === ".") i++;
     } else {
       current += path[i];

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -98,6 +98,16 @@ describe("parsePath", () => {
     expect(parsePath("items[0].name")).toEqual(["items", 0, "name"]);
   });
 
+  test("rejects ambiguous key text after bracket index", () => {
+    expect(() => parsePath("items[0]name")).toThrow('Invalid path "items[0]name"');
+    expect(() => parsePath("[0]name")).toThrow('Invalid path "[0]name"');
+  });
+
+  test("allows explicit path separators after bracket index", () => {
+    expect(parsePath("items[0][1]")).toEqual(["items", 0, 1]);
+    expect(parsePath("[0].name")).toEqual([0, "name"]);
+  });
+
   test("nested brackets", () => {
     expect(parsePath("[0][1]")).toEqual([0, 1]);
   });


### PR DESCRIPTION
## Summary

- reject path text that appears immediately after a bracketed array index
- keep dotted and bracketed continuations valid
- add regression coverage for `items[0]name` and `[0]name`

Fixes #71.

## Checks

- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run smoke:package`