### PR TITLE
Fix reserved metadata root field collisions

### DIFF
--- a/.changeset/reserved-types-key.md
+++ b/.changeset/reserved-types-key.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject plain-value root fields that collide with the reserved metadata key.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ console.log(entries);
 // ]
 ```
 
+`encode()` reserves the root path named by `typesKey` for metadata. With the default
+configuration, a root object field named `$types` throws a path-aware `TypeError`;
+rename that field or pass a different `typesKey` if you need to encode it as user data.
+
 ## `decode()`
 
 Decode `FormData` entries back into a typed value.

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -265,6 +265,14 @@ function isFileValue(value: unknown): value is File {
   return typeof File !== "undefined" && value instanceof File;
 }
 
+function assertDataPathNotReserved(path: string, typesKey: string): void {
+  if (path !== typesKey) return;
+
+  throw new TypeError(
+    `Path "${path}" is reserved for superformdata metadata; pass a different typesKey option or rename the root field.`,
+  );
+}
+
 function walk(
   value: unknown,
   path: string,
@@ -275,14 +283,13 @@ function walk(
   fileStrategy: FileStrategy,
   typesKey: string,
 ): void {
+  assertDataPathNotReserved(path, typesKey);
+
   if (isFileValue(value)) {
     if (fileStrategy !== "preserve") {
       throw new TypeError(
         `File values are not supported by superformdata at path "${path}". Handle file uploads separately or pass { files: "preserve" }.`,
       );
-    }
-    if (path === typesKey) {
-      throw new TypeError(`Invalid superformdata metadata: "${typesKey}" field must be a string`);
     }
     entries.push([path, value]);
     return;

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -560,7 +560,19 @@ describe("encode/decode round-trip", () => {
     const file = new File(["content"], "metadata.txt");
 
     expect(() => encode({ $types: file }, { files: "preserve" })).toThrow(
-      'Invalid superformdata metadata: "$types" field must be a string',
+      'Path "$types" is reserved for superformdata metadata',
+    );
+  });
+
+  test("encode rejects root string data fields that use the metadata key", () => {
+    expect(() => encode({ $types: "user data" })).toThrow(
+      'Path "$types" is reserved for superformdata metadata; pass a different typesKey option or rename the root field.',
+    );
+  });
+
+  test("encode rejects root typed data fields that use the metadata key", () => {
+    expect(() => encode({ $types: 1 })).toThrow(
+      'Path "$types" is reserved for superformdata metadata; pass a different typesKey option or rename the root field.',
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes #64 by rejecting plain-value root fields whose encoded path collides with the reserved metadata key.

## Root Cause

`encode()` emitted root object fields named `$types` as normal data entries while `decode()` always consumed `$types` as superformdata metadata. That made `{ $types: "user data" }` decode as malformed metadata and `{ $types: 1 }` emit duplicate `$types` entries.

## Changes

- Added a path-aware reserved metadata guard in the plain-value encoder walk before any data entry or type metadata can be emitted at `typesKey`.
- Added regression tests for root `$types` string and typed values.
- Updated the existing root `$types` File test to expect the same reserved-path behavior.
- Documented the reserved root `typesKey` behavior in the README.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun test`
- `bun typecheck`
- `git diff --check`
