### PR TITLE
fix: validate sparse array metadata

### DIFF
--- a/.changeset/validate-sparse-array-metadata.md
+++ b/.changeset/validate-sparse-array-metadata.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Reject sparse array metadata that would truncate decoded values.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -145,9 +145,12 @@ export function decode<T = unknown>(
 
   for (const [path, segments, length] of sortedSparseArrays) {
     if (path === "") {
-      if (Array.isArray(result)) result.length = length;
+      if (Array.isArray(result)) {
+        validateSparseArrayLength(path, result, length);
+        result.length = length;
+      }
     } else {
-      resizeArray(result, segments, length);
+      resizeArray(result, path, segments, length);
     }
   }
 
@@ -278,7 +281,12 @@ function isConvertedStructuralValue(value: unknown, typeId: string): boolean {
   return (typeId === "set" && value instanceof Set) || (typeId === "map" && value instanceof Map);
 }
 
-function resizeArray(root: unknown, segments: readonly PathSegment[], length: number): void {
+function resizeArray(
+  root: unknown,
+  path: string,
+  segments: readonly PathSegment[],
+  length: number,
+): void {
   if (segments.length === 0) return;
 
   let current: Record<string | number, unknown> = root as Record<string | number, unknown>;
@@ -289,5 +297,19 @@ function resizeArray(root: unknown, segments: readonly PathSegment[], length: nu
 
   const lastSeg = segments[segments.length - 1]!;
   const value = current[lastSeg];
-  if (Array.isArray(value)) value.length = length;
+  if (!Array.isArray(value)) return;
+
+  validateSparseArrayLength(path, value, length);
+  value.length = length;
+}
+
+function validateSparseArrayLength(path: string, value: readonly unknown[], length: number): void {
+  for (const key of Object.keys(value)) {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < length) continue;
+
+    throw new TypeError(
+      `Invalid superformdata metadata: sparse array length ${length} at path "${path}" would truncate decoded index ${index}`,
+    );
+  }
 }

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -442,6 +442,28 @@ describe("encode/decode round-trip", () => {
     expect(() => decode([["a[100000000]", "x"]])).toThrow("Array index too large");
   });
 
+  test("decode rejects sparse array metadata shorter than decoded indexes", () => {
+    expect(() =>
+      decode([
+        ["items[5]", "x"],
+        ["$types", JSON.stringify({ items: "array:2" })],
+      ]),
+    ).toThrow(
+      'Invalid superformdata metadata: sparse array length 2 at path "items" would truncate decoded index 5',
+    );
+  });
+
+  test("decode rejects large sparse array metadata shorter than decoded indexes", () => {
+    expect(() =>
+      decode([
+        ["items[100000]", "x"],
+        ["$types", JSON.stringify({ items: "array:100000" })],
+      ]),
+    ).toThrow(
+      'Invalid superformdata metadata: sparse array length 100000 at path "items" would truncate decoded index 100000',
+    );
+  });
+
   test("decode rejects malformed path syntax", () => {
     expect(() => decode([["items[0", "x"]])).toThrow(
       'Invalid path "items[0": missing closing bracket',


### PR DESCRIPTION
## Summary

- Validate sparse array metadata before resizing decoded arrays.
- Throw a clear metadata error if the declared `array:<length>` would truncate decoded entries.
- Add regression coverage for `array:2` with `items[5]` and `array:100000` with `items[100000]`.
- Add a patch changeset for the decoder bug fix.

Closes #67.

## Testing

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`