### PR TITLE
fix: strictly match decodeRequest content types

### DIFF
--- a/.changeset/strict-content-type-decoding.md
+++ b/.changeset/strict-content-type-decoding.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Normalize and strictly match decodeRequest content types before decoding request bodies.

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -216,7 +216,7 @@ export async function decodeRequest<T = unknown>(
   const mediaType = contentType.split(";", 1)[0]!.trim().toLowerCase();
 
   if (mediaType === "multipart/form-data") {
-    return decode<T>(await request.formData(), options);
+    return decode<T>(await withNormalizedContentType(request, mediaType).formData(), options);
   }
 
   if (mediaType === "application/x-www-form-urlencoded") {
@@ -239,6 +239,15 @@ export async function decodeRequest<T = unknown>(
   throw new TypeError(
     `Unsupported content-type: "${contentType}". decodeRequest() only supports multipart/form-data, application/x-www-form-urlencoded, and text/plain.`,
   );
+}
+
+function withNormalizedContentType(request: Request, mediaType: string): Request {
+  const headers = new Headers(request.headers);
+  const contentType = headers.get("content-type");
+  const parameters = contentType?.split(";").slice(1).join(";") ?? "";
+  headers.set("content-type", parameters ? `${mediaType};${parameters}` : mediaType);
+
+  return new Request(request, { headers });
 }
 
 function throwStructuralMismatch(path: string, typeId: string): never {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -213,15 +213,17 @@ export async function decodeRequest<T = unknown>(
   options?: DecodeOptions,
 ): Promise<T> {
   const contentType = request.headers.get("content-type") ?? "";
+  const mediaType = contentType.split(";", 1)[0]!.trim().toLowerCase();
 
-  if (
-    contentType.includes("multipart/form-data") ||
-    contentType.includes("application/x-www-form-urlencoded")
-  ) {
+  if (mediaType === "multipart/form-data") {
     return decode<T>(await request.formData(), options);
   }
 
-  if (contentType.includes("text/plain")) {
+  if (mediaType === "application/x-www-form-urlencoded") {
+    return decode<T>(new URLSearchParams(await request.text()), options);
+  }
+
+  if (mediaType === "text/plain") {
     const text = await request.text();
     const entries: [string, string][] = text
       .split(/\r?\n/)

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -837,6 +837,51 @@ describe("decodeRequest", () => {
     expect(await decodeRequest<typeof input>(request)).toEqual(input);
   });
 
+  test("application/x-www-form-urlencoded with parameters", async () => {
+    const input = { name: "Alice", age: 30 };
+    const entries = encode(input);
+    const body = entries
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join("&");
+
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded; charset=UTF-8" },
+      body,
+    });
+
+    expect(await decodeRequest<typeof input>(request)).toEqual(input);
+  });
+
+  test("accepts supported content-types case-insensitively", async () => {
+    const input = { name: "Alice" };
+    const entries = encode(input);
+    const formBody = entries
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join("&");
+    const textBody = entries.map(([k, v]) => `${k}=${v}`).join("\n");
+
+    await expect(
+      decodeRequest<typeof input>(
+        new Request("http://localhost", {
+          method: "POST",
+          headers: { "content-type": "Application/X-WWW-Form-Urlencoded" },
+          body: formBody,
+        }),
+      ),
+    ).resolves.toEqual(input);
+
+    await expect(
+      decodeRequest<typeof input>(
+        new Request("http://localhost", {
+          method: "POST",
+          headers: { "content-type": "Text/Plain" },
+          body: textBody,
+        }),
+      ),
+    ).resolves.toEqual(input);
+  });
+
   test("multipart/form-data", async () => {
     const input = { name: "Alice", active: true };
     const entries = encode(input);
@@ -901,6 +946,25 @@ describe("decodeRequest", () => {
     });
 
     await expect(decodeRequest(request)).rejects.toThrow(/Unsupported content-type/);
+  });
+
+  test("rejects content-types that only contain supported type substrings", async () => {
+    const requests = [
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencodedx" },
+        body: "name=Alice",
+      }),
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "content-type": "not-text/plain" },
+        body: "name=Alice",
+      }),
+    ];
+
+    for (const request of requests) {
+      await expect(decodeRequest(request)).rejects.toThrow(/Unsupported content-type/);
+    }
   });
 
   test("text/plain with \\n line endings", async () => {

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -859,6 +859,13 @@ describe("decodeRequest", () => {
     const formBody = entries
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
       .join("&");
+    const multipartBoundary = "superformdata-test-boundary";
+    const multipartBody = entries
+      .map(
+        ([key, value]) =>
+          `--${multipartBoundary}\r\nContent-Disposition: form-data; name="${key}"\r\n\r\n${value}\r\n`,
+      )
+      .join("");
     const textBody = entries.map(([k, v]) => `${k}=${v}`).join("\n");
 
     await expect(
@@ -867,6 +874,16 @@ describe("decodeRequest", () => {
           method: "POST",
           headers: { "content-type": "Application/X-WWW-Form-Urlencoded" },
           body: formBody,
+        }),
+      ),
+    ).resolves.toEqual(input);
+
+    await expect(
+      decodeRequest<typeof input>(
+        new Request("http://localhost", {
+          method: "POST",
+          headers: { "content-type": `Multipart/Form-Data; boundary=${multipartBoundary}` },
+          body: `${multipartBody}--${multipartBoundary}--\r\n`,
         }),
       ),
     ).resolves.toEqual(input);


### PR DESCRIPTION
## Summary
- Normalize the `content-type` header to the media type before parameters and compare supported types exactly.
- Parse `application/x-www-form-urlencoded` bodies via `URLSearchParams` so mixed-case media types decode consistently across runtimes.
- Add regression coverage for mixed-case supported types, parameterized URL-encoded content types, and invalid near-match content types.
- Add a patch changeset.

## Verification
- `bun fmt`
- `bun run lint:fix`
- `bun run lint`
- `bun test`
- `bun run typecheck`

Closes #68