### PR TITLE
[codex] Validate form submitters

### DIFF
--- a/.changeset/validate-form-submitter.md
+++ b/.changeset/validate-form-submitter.md
@@ -1,0 +1,5 @@
+---
+"superformdata": patch
+---
+
+Validate `encode(form, { submitter })` submitters before encoding so non-submit controls and controls owned by another form throw like native `FormData(form, submitter)`.

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -83,6 +83,27 @@ function isSubmitButton(el: Element): boolean {
   return false;
 }
 
+function validateSubmitter(form: HTMLFormElement, submitter?: HTMLElement | null): void {
+  if (submitter == null) return;
+
+  if (!isSubmitButton(submitter)) {
+    throw new TypeError("The specified element is not a submit button");
+  }
+
+  if (submitter instanceof HTMLButtonElement || submitter instanceof HTMLInputElement) {
+    if (submitter.form === form) return;
+  }
+
+  if (typeof DOMException !== "undefined") {
+    throw new DOMException(
+      "The specified element is not owned by this form element",
+      "NotFoundError",
+    );
+  }
+
+  throw new Error("The specified element is not owned by this form element");
+}
+
 function isSubmittableFormControl(
   element: Element,
 ): element is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | HTMLButtonElement {
@@ -117,6 +138,8 @@ function encodeForm(
   explicitTypes?: Record<string, string>,
   submitter?: HTMLElement | null,
 ): EncodedEntry[] | PreservedFileEntry[] {
+  validateSubmitter(form, submitter);
+
   const entries: PreservedFileEntry[] = [];
   const types: Record<string, string> = { ...explicitTypes };
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -453,18 +453,38 @@ describe("encode(form)", () => {
     const button = form.querySelector<HTMLButtonElement>("button")!;
     const entries = encode(form, { submitter: button });
 
-    expect(entries).toContainEqual(["title", "hello"]);
-    expect(entries).toContainEqual(["action", "save"]);
+    expect(entries).toEqual([
+      ["title", "hello"],
+      ["action", "save"],
+    ]);
   });
 
-  test("always excludes button[type=button]", () => {
+  test("rejects button[type=button] passed as submitter", () => {
     const form = createForm(
       '<input name="title" value="hello" /><button name="action" type="button" value="click">Click</button>',
     );
     const button = form.querySelector<HTMLButtonElement>("button")!;
-    const entries = encode(form, { submitter: button });
 
-    expect(entries).toEqual([["title", "hello"]]);
+    expect(() => encode(form, { submitter: button })).toThrow(TypeError);
+  });
+
+  test("rejects non-submit input passed as submitter", () => {
+    const form = createForm(
+      '<input name="title" value="hello" /><input name="notSubmit" value="x" />',
+    );
+    const input = form.querySelector<HTMLInputElement>('input[name="notSubmit"]')!;
+
+    expect(() => encode(form, { submitter: input })).toThrow(TypeError);
+  });
+
+  test("rejects submit buttons not owned by the form", () => {
+    document.body.innerHTML =
+      '<form id="target"><input name="title" value="hello" /></form>' +
+      '<form id="other"><button name="action" value="save">Save</button></form>';
+    const form = document.querySelector<HTMLFormElement>("#target")!;
+    const button = document.querySelector<HTMLButtonElement>("#other button")!;
+
+    expect(() => encode(form, { submitter: button })).toThrow();
   });
 
   test("excludes input[type=submit] without submitter", () => {
@@ -483,8 +503,10 @@ describe("encode(form)", () => {
     const submitInput = form.querySelector<HTMLInputElement>('input[type="submit"]')!;
     const entries = encode(form, { submitter: submitInput });
 
-    expect(entries).toContainEqual(["title", "hello"]);
-    expect(entries).toContainEqual(["sub", "Send"]);
+    expect(entries).toEqual([
+      ["title", "hello"],
+      ["sub", "Send"],
+    ]);
   });
 
   test("includes input[type=image] when passed as submitter (encodes name+value, not coordinates)", () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -484,7 +484,13 @@ describe("encode(form)", () => {
     const form = document.querySelector<HTMLFormElement>("#target")!;
     const button = document.querySelector<HTMLButtonElement>("#other button")!;
 
-    expect(() => encode(form, { submitter: button })).toThrow();
+    try {
+      encode(form, { submitter: button });
+      throw new Error("Expected encode to reject submitter owned by another form");
+    } catch (error) {
+      expect(error).toBeInstanceOf(DOMException);
+      expect((error as DOMException).name).toBe("NotFoundError");
+    }
   });
 
   test("excludes input[type=submit] without submitter", () => {


### PR DESCRIPTION
## Summary

Fixes #69.

This updates `encode(form, { submitter })` to validate the submitter before walking form controls, matching native `FormData(form, submitter)` behavior more closely.

## Root Cause

`submitter` was only compared while handling submit buttons in the form element loop. That meant non-submit controls and submit buttons owned by a different form were never rejected up front, so encoding continued and returned normal entries.

## Changes

- Reject non-submit controls passed as `submitter` with `TypeError`.
- Reject submit buttons not owned by the encoded form with a `NotFoundError` `DOMException` where available.
- Preserve valid submit button inclusion and assert it is emitted exactly once.
- Add a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
